### PR TITLE
Git improvements

### DIFF
--- a/src/main/groovy/release/GitReleasePlugin.groovy
+++ b/src/main/groovy/release/GitReleasePlugin.groovy
@@ -9,115 +9,133 @@ import org.gradle.api.GradleException
  */
 class GitReleasePlugin extends BaseScmPlugin<GitReleasePluginConvention> {
 
-	private static final String LINE = '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
+    private static final String LINE = '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 
-	private static final String UNCOMMITTED = 'uncommitted'
-	private static final String UNVERSIONED = 'unversioned'
-	private static final String AHEAD = 'ahead'
-	private static final String BEHIND = 'behind'
+    private static final String UNCOMMITTED = 'uncommitted'
+    private static final String UNVERSIONED = 'unversioned'
+    private static final String AHEAD = 'ahead'
+    private static final String BEHIND = 'behind'
 
-	@Override
-	void init() {
-		if (convention().requireBranch) {
+    @Override
+    void init() {
+        if (convention().requireBranch) {
 
-			def branch = gitCurrentBranch()
+            def branch = gitCurrentBranch()
 
-			if (!(branch == convention().requireBranch)) {
-				throw new GradleException("Current Git branch is \"$branch\" and not \"${ convention().requireBranch }\".")
-			}
-		}
-	}
-
-
-	@Override
-	GitReleasePluginConvention buildConventionInstance() { releaseConvention().git }
+            if (!(branch == convention().requireBranch)) {
+                throw new GradleException("Current Git branch is \"$branch\" and not \"${ convention().requireBranch }\".")
+            }
+        }
+    }
 
 
-	@Override
-	void checkCommitNeeded() {
-
-		def status = gitStatus()
-
-		if (status[UNVERSIONED]) {
-			warnOrThrow(releaseConvention().failOnUnversionedFiles,
-					(['You have unversioned files:', LINE, * status[UNVERSIONED], LINE] as String[]).join('\n'))
-		}
-
-		if (status[UNCOMMITTED]) {
-			warnOrThrow(releaseConvention().failOnCommitNeeded,
-					(['You have uncommitted files:', LINE, * status[UNCOMMITTED], LINE] as String[]).join('\n'))
-		}
-
-	}
+    @Override
+    GitReleasePluginConvention buildConventionInstance() { releaseConvention().git }
 
 
-	@Override
-	void checkUpdateNeeded() {
+    @Override
+    void checkCommitNeeded() {
 
-		exec(['git', 'remote', 'update'], '')
+        def status = gitStatus()
 
-		def status = gitRemoteStatus()
+        if (status[UNVERSIONED]) {
+            warnOrThrow(releaseConvention().failOnUnversionedFiles,
+                    (['You have unversioned files:', LINE, * status[UNVERSIONED], LINE] as String[]).join('\n'))
+        }
 
-		if (status[AHEAD]) {
-			warnOrThrow(releaseConvention().failOnPublishNeeded, "You have ${status[AHEAD]} local change(s) to push.")
-		}
+        if (status[UNCOMMITTED]) {
+            warnOrThrow(releaseConvention().failOnCommitNeeded,
+                    (['You have uncommitted files:', LINE, * status[UNCOMMITTED], LINE] as String[]).join('\n'))
+        }
 
-		if (status[BEHIND]) {
-			warnOrThrow(releaseConvention().failOnUpdateNeeded, "You have ${status[BEHIND]} remote change(s) to pull.")
-		}
-	}
-
-
-	@Override
-	void createReleaseTag(String message = "") {
-		def tagName = tagName()
-		exec(['git', 'tag', '-a', tagName, '-m', message ?: "Created by Release Plugin: ${tagName}"], "Duplicate tag [$tagName]", 'already exists')
-		exec(['git', 'push', 'origin', tagName], '', '! [rejected]', 'error: ', 'fatal: ')
-	}
+    }
 
 
-	@Override
-	void commit(String message) {
-		exec(['git', 'commit', '-a', '-m', message], '')
-		exec(['git', 'push', 'origin'], '', '! [rejected]', 'error: ', 'fatal: ')
-	}
+    @Override
+    void checkUpdateNeeded() {
 
-	@Override
-	void revert() {
-		exec(['git', 'reset', '--hard', 'HEAD', findPropertiesFile().name], "Error reverting changes made by the release plugin.")
-	}
+        gitExec(['remote', 'update'], '')
+
+        def status = gitRemoteStatus()
+
+        if (status[AHEAD]) {
+            warnOrThrow(releaseConvention().failOnPublishNeeded, "You have ${status[AHEAD]} local change(s) to push.")
+        }
+
+        if (status[BEHIND]) {
+            warnOrThrow(releaseConvention().failOnUpdateNeeded, "You have ${status[BEHIND]} remote change(s) to pull.")
+        }
+    }
+
+
+    @Override
+    void createReleaseTag(String message = "") {
+        def tagName = tagName()
+        gitExec(['tag', '-a', tagName, '-m', message ?: "Created by Release Plugin: ${tagName}"], "Duplicate tag [$tagName]", 'already exists')
+        gitExec(['push', 'origin', tagName], '', '! [rejected]', 'error: ', 'fatal: ')
+    }
+
+
+    @Override
+    void commit(String message) {
+        gitExec(['commit', '-a', '-m', message], '')
+        def pushCmd = ['push', 'origin']
+        if (convention().pushToCurrentBranch) {
+            pushCmd << getCurrentBranch()
+        }
+        gitExec(pushCmd, '', '! [rejected]', 'error: ', 'fatal: ')
+    }
+
+    @Override
+    void revert() {
+        gitExec(['reset', '--hard', 'HEAD', findPropertiesFile().name], "Error reverting changes made by the release plugin.")
+    }
 
 
 
-	private String gitCurrentBranch() {
-		def matches = exec('git', 'branch').readLines().grep(~/\s*\*.*/)
-		matches[0].trim() - (~/^\*\s+/)
-	}
+    private String getCurrentBranch() {
+        def matches = gitExec('branch').readLines().grep(~/\s*\*.*/)
+        matches[0].trim() - (~/^\*\s+/)
+    }
 
-	private Map<String, List<String>> gitStatus() {
-		exec('git', 'status', '--porcelain').readLines().groupBy {
-			if (it ==~ /^\s*\?{2}.*/) {
-				UNVERSIONED
-			} else {
-				UNCOMMITTED
-			}
-		}
-	}
+    private Map<String, List<String>> gitStatus() {
+        gitExec('status', '--porcelain').readLines().groupBy {
+            if (it ==~ /^\s*\?{2}.*/) {
+                UNVERSIONED
+            } else {
+                UNCOMMITTED
+            }
+        }
+    }
 
-	private Map<String, Integer> gitRemoteStatus() {
-		def branchStatus = exec('git', 'status', '-sb').readLines()[0]
-		def aheadMatcher = branchStatus =~ /.*ahead (\d+).*/
-		def behindMatcher = branchStatus =~ /.*behind (\d+).*/
+    private Map<String, Integer> gitRemoteStatus() {
+        def branchStatus = gitExec('status', '-sb').readLines()[0]
+        def aheadMatcher = branchStatus =~ /.*ahead (\d+).*/
+        def behindMatcher = branchStatus =~ /.*behind (\d+).*/
 
-		def remoteStatus = [:]
+        def remoteStatus = [:]
 
-		if (aheadMatcher.matches()) {
-			remoteStatus[AHEAD] = aheadMatcher[0][1]
-		}
-		if (behindMatcher.matches()) {
-			remoteStatus[BEHIND] = behindMatcher[0][1]
-		}
-		remoteStatus
-	}
+        if (aheadMatcher.matches()) {
+            remoteStatus[AHEAD] = aheadMatcher[0][1]
+        }
+        if (behindMatcher.matches()) {
+            remoteStatus[BEHIND] = behindMatcher[0][1]
+        }
+        remoteStatus
+    }
 
+    String gitExec(Collection<String> params, String errorMessage, String... errorPattern) {
+        def gitDir = project.rootProject.file(".git").canonicalPath.replaceAll("\\\\", "/")
+        def workTree = project.rootProject.projectDir.canonicalPath.replaceAll("\\\\", "/")
+        def cmdLine = ['git', "--git-dir=${gitDir}", "--work-tree=${workTree}"].plus(params)
+        return exec(cmdLine, errorMessage, errorPattern)
+    }
+
+    String gitExec(String... commands) {
+        def gitDir = project.rootProject.file(".git").canonicalPath.replaceAll("\\\\", "/")
+        def workTree = project.rootProject.projectDir.canonicalPath.replaceAll("\\\\", "/")
+        def cmdLine = ['git', "--git-dir=${gitDir}", "--work-tree=${workTree}"]
+        cmdLine.addAll commands
+        return exec(cmdLine as String[])
+    }
 }

--- a/src/main/groovy/release/GitReleasePluginConvention.groovy
+++ b/src/main/groovy/release/GitReleasePluginConvention.groovy
@@ -7,4 +7,5 @@ package release
  */
 class GitReleasePluginConvention {
     String requireBranch = 'master'
+    boolean pushToCurrentBranch = false
 }

--- a/src/test/groovy/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/release/GitReleasePluginTests.groovy
@@ -1,24 +1,61 @@
 package release
 
-import org.gradle.api.Plugin
-import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
 
-/**
- * User: elberry
- * User: evgenyg
- * Date: 9/21/11
- */
-@Mixin( PluginHelper )
-@SuppressWarnings( 'JUnitPublicNonTestMethod' )
-class GitReleasePluginTests extends AbstractReleasePluginTests {
+@Mixin(PluginHelper)
+class GitReleasePluginTests extends Specification {
 
-	@Override
-    @SuppressWarnings( 'GetterMethodCouldBeProperty' )
-	Class<? extends Plugin<Project>> getPluginClass() { BzrReleasePlugin }
+    def testDir = new File("build/tmp/test/release")
 
-	@Override
-	void initProject( File root, String projectName ) {
+    def localRepo = new File(testDir, "GitReleasePluginTestLocal")
+    def remoteRepo = new File(testDir, "GitReleasePluginTestRemote")
 
-        exec( false, [:], root, *[ 'git', 'init', projectName ] )
-	}
+    def setup() {
+        testDir.mkdirs()
+
+        exec(true, [:], testDir, 'git', 'init', "GitReleasePluginTestRemote")//create remote repo
+        exec(true, [:], remoteRepo, 'git', 'config', '--add', 'receive.denyCurrentBranch', 'ignore')//suppress errors when pushing
+
+        exec(false, [:], testDir, 'git', 'clone', remoteRepo.canonicalPath, 'GitReleasePluginTestLocal')
+
+        project = ProjectBuilder.builder().withName("GitReleasePluginTest").withProjectDir(localRepo).build()
+        project.version = "1.1"
+        project.apply plugin: ReleasePlugin
+        def props = project.file("gradle.properties")
+        props.withWriter { it << "version=${project.version}" }
+        exec(true, [:], localRepo, 'git', 'add', 'gradle.properties')
+    }
+
+    def cleanup() {
+        if (testDir.exists()) testDir.deleteDir()
+    }
+
+    def 'should apply ReleasePlugin and GitReleasePlugin plugin'() {
+        expect:
+        project.plugins.findPlugin(ReleasePlugin)
+        and:
+        project.plugins.findPlugin(GitReleasePlugin)
+    }
+
+    def 'should push new version to remote tracking branch by default'() {
+        when:
+        project.commitNewVersion.execute()
+        exec(true, [:], remoteRepo, 'git', 'reset', '--hard', 'HEAD')
+        then:
+        remoteRepo.list().any { it == 'gradle.properties' }
+    }
+
+    def 'when pushToCurrentBranch then push new version to remote branch with same name as working'() {
+        given:
+        project.git.pushToCurrentBranch = true
+        exec(true, [:], localRepo, 'git', 'checkout', '-B', 'myBranch')
+        when:
+        project.commitNewVersion.execute()
+        exec(false, [:], remoteRepo, 'git', 'checkout', 'myBranch')
+        exec(false, [:], remoteRepo, 'git', 'reset', '--hard', 'HEAD')
+        then:
+        remoteRepo.list().any { it == 'gradle.properties' }
+    }
+
 }


### PR DESCRIPTION
1. Added parameters to git command that are setting working directory to project's dir. This helps to handle situations when gradle is run outside project directory using -p option. Useful for CI server integration etc.
2.  Added property that forces pushing to branch with the same name as current. Could be useful in some situation when no tracking branch information present or in my case when IntelliJ IDEA breaks tracking information on pushing.
