### PR TITLE
Fixes #32 - add scmRootDir parameter

### DIFF
--- a/src/main/groovy/release/GitReleasePlugin.groovy
+++ b/src/main/groovy/release/GitReleasePlugin.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.GradleException
 /**
  * @author elberry
  * @author evgenyg
+ * @author szpak
  * Created: Tue Aug 09 23:24:40 PDT 2011
  */
 class GitReleasePlugin extends BaseScmPlugin<GitReleasePluginConvention> {
@@ -133,16 +134,32 @@ class GitReleasePlugin extends BaseScmPlugin<GitReleasePluginConvention> {
 	}
 
 	String gitExec(Collection<String> params, String errorMessage, String... errorPattern) {
-		def gitDir = project.rootProject.file(".git").canonicalPath.replaceAll("\\\\", "/")
-		def workTree = project.rootProject.projectDir.canonicalPath.replaceAll("\\\\", "/")
+		def gitDir = resolveGitDir()
+		def workTree = resolveWorkTree()
 		def cmdLine = ['git', "--git-dir=${gitDir}", "--work-tree=${workTree}"].plus(params)
 		log.debug("gitExec - 1 - {cmdLine: ${cmdLine}, errorMessage: ${errorMessage}, errorPattern: ${errorPattern}}")
 		return exec(cmdLine, errorMessage, errorPattern)
 	}
 
+	private String resolveGitDir() {
+		if (convention().scmRootDir) {
+			project.rootProject.file(convention().scmRootDir + "/.git").canonicalPath.replaceAll("\\\\", "/")
+		} else {
+			project.rootProject.file(".git").canonicalPath.replaceAll("\\\\", "/")
+		}
+	}
+
+	private String resolveWorkTree() {
+		if (convention().scmRootDir) {
+			project.rootProject.file(convention().scmRootDir).canonicalPath.replaceAll("\\\\", "/")
+		} else {
+			project.rootProject.projectDir.canonicalPath.replaceAll("\\\\", "/")
+		}
+	}
+
 	String gitExec(String... commands) {
-		def gitDir = project.rootProject.file(".git").canonicalPath.replaceAll("\\\\", "/")
-		def workTree = project.rootProject.projectDir.canonicalPath.replaceAll("\\\\", "/")
+		def gitDir = resolveGitDir()
+		def workTree = resolveWorkTree()
 		def cmdLine = ['git', "--git-dir=${gitDir}", "--work-tree=${workTree}"]
 		cmdLine.addAll commands
 		log.debug("gitExec - 2 - {cmdLine: ${cmdLine}}")

--- a/src/main/groovy/release/GitReleasePluginConvention.groovy
+++ b/src/main/groovy/release/GitReleasePluginConvention.groovy
@@ -3,9 +3,11 @@ package release
 /**
  * @author elberry
  * @author evgenyg
+ * @author szpak
  * Created: Tue Aug 09 23:24:40 PDT 2011
  */
 class GitReleasePluginConvention {
     String requireBranch = 'master'
     boolean pushToCurrentBranch = false
+    String scmRootDir
 }

--- a/src/test/groovy/release/GitReleasePluginScmRootTests.groovy
+++ b/src/test/groovy/release/GitReleasePluginScmRootTests.groovy
@@ -1,0 +1,41 @@
+package release
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+
+@Mixin(PluginHelper)
+class GitReleasePluginScmRootTests extends GitSpecification {
+	def setup() {
+		final subdirectoryInRepo = new File(localGit.repository.getWorkTree(), "subdirectory")
+		project = ProjectBuilder.builder().withName("GitReleasePluginTest").withProjectDir(subdirectoryInRepo).build()
+		project.apply plugin: ReleasePlugin
+	}
+
+	def "scmRootDir parameter as relative path should allow to use git root located above project directory"() {
+		given:
+		project.git.scmRootDir = "../"
+		when:
+		project.checkUpdateNeeded.execute()
+		then:
+		noExceptionThrown()
+	}
+
+	def "scmRootDir parameter as absolute path should allow to use git root located above project directory"() {
+		given:
+		project.git.scmRootDir = localGit.repository.getWorkTree().absolutePath
+		when:
+		project.checkUpdateNeeded.execute()
+		then:
+		noExceptionThrown()
+	}
+
+	def "should fail without set scmRoot for project in repo subdirectory"() {
+		given:
+		project.git.scmRootDir = null
+		when:
+		project.checkUpdateNeeded.execute()
+		then:
+		GradleException e = thrown()
+		e.cause.message.contains("Not a git repository")
+	}
+}


### PR DESCRIPTION
I added scmRootDir (currently only in Git) which allow to define a Git root directory. It works in my project.

Feel free to refactor/adjust to the project conventions.
