### PR TITLE
fix problem with sending empty remote branch name in push command

### DIFF
--- a/src/main/groovy/release/GitReleasePlugin.groovy
+++ b/src/main/groovy/release/GitReleasePlugin.groovy
@@ -85,7 +85,7 @@ class GitReleasePlugin extends BaseScmPlugin<GitReleasePluginConvention> {
 		} else {
 			def requireBranch = convention().requireBranch
 			log.debug("commit - {requireBranch: ${requireBranch}}")
-			if(requireBranch != null) {
+			if(requireBranch) {
 				pushCmd << requireBranch
 			} else {
 				pushCmd << 'master'


### PR DESCRIPTION
In one place `if (requireBranch != null)` construction was used instead of `if (requireBranch)` what causes:

```
00:02:40  >>> Running [git, --git-dir=/home/foo/bar/.git, --work-tree=/home/foo/bar, push, origin, ]: [][fatal: remote part of refspec is not a valid name in 
```

for requireBranch parameter set to ''.
