### PR TITLE
Fixes #33 - add pushChanges parameter (WIP - without automatic tests)

### DIFF
--- a/src/main/groovy/release/ReleasePluginConvention.groovy
+++ b/src/main/groovy/release/ReleasePluginConvention.groovy
@@ -16,6 +16,7 @@ class ReleasePluginConvention {
 	boolean failOnUnversionedFiles = true
 	boolean failOnUpdateNeeded = true
 	boolean revertOnFail = true // will use the SCM plugin to revert any uncommitted changes in the project.
+    boolean pushChanges = true  // push changes to remote repo (supported only in DVCS)
 	String preCommitText = "" // good place for code review overrides and ticket numbers
 	String preTagCommitMessage = "[Gradle Release Plugin] - pre tag commit: "
 	String tagCommitMessage = "[Gradle Release Plugin] - creating tag: "

--- a/src/test/groovy/release/GitReleasePluginCreateReleaseTagTests.groovy
+++ b/src/test/groovy/release/GitReleasePluginCreateReleaseTagTests.groovy
@@ -17,6 +17,7 @@ class GitReleasePluginCreateReleaseTagTests extends GitSpecification {
         when:
         project.createReleaseTag.execute()
         then:
+        //TODO: MZA: It won't work with parallel tests
         localGit.tagList().call()*.name == ["refs/tags/${tagName()}"]
         remoteGit.tagList().call()*.name == ["refs/tags/${tagName()}"]
     }
@@ -31,4 +32,16 @@ class GitReleasePluginCreateReleaseTagTests extends GitSpecification {
         thrown GradleException
     }
 
+    def 'createReleaseTag with disabled pushing changes should only create tag and not push to remote'() {
+        given:
+        project.version = '1.3'
+        project.release {
+            pushChanges = false
+        }
+        when:
+        project.createReleaseTag.execute()
+        then:
+        localGit.tagList().call().findAll { it.name == "refs/tags/${tagName()}" }.size() == 1
+        remoteGit.tagList().call().findAll { it.name == "refs/tags/${tagName()}" }.isEmpty()
+    }
 }


### PR DESCRIPTION
Implemented a pushChanges parameter for Git which allows to disable pushing changes to a remote repo. In the context of discussion in #33 it is only a partial implementation without proper automatic tests to have a reference further changes.

It contains a fix from #40 (a wrongly interpreted requireBranch parameter).