### PR TITLE
Issue #44 Release version and new version as build parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,10 @@ This means the gradle-release plugin does not support sub projects that have dif
 
 In a continuous integration environment like Jenkins or Hudson, you don't want to have an interactive release process. To avoid having to enter any information manually during the process, you can tell the plugin to automatically set and update the version number.
 
-You can do this by setting the 'gradle.release.useAutomaticVersion' property on the command line, or in Jenkins when you execute gradle.
+You can do this by setting the `gradle.release.useAutomaticVersion` property on the command line, or in Jenkins when you execute gradle. The version to release and the next version can be optionally defined using the properties `releaseVersion` and `nextVersion`. 
 
-    -Pgradle.release.useAutomaticVersion=true
+    -Pgradle.release.useAutomaticVersion=true -PreleaseVersion=1.0.0 -PnewVersion=1.1.0-SNAPSHOT
+
 
 ## Getting Help
 


### PR DESCRIPTION
This pull request is about Issue #44 "Release version and new version as build parameters". It features two new command line properties `releaseVersion` and `newVersion`. When used in conjunction with `gradle.release.useAutomaticVersion` the release and next version is taken from the properties.
