### PR TITLE
Fix failing tests for git identity

### DIFF
--- a/src/test/groovy/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/release/GitReleasePluginTests.groovy
@@ -21,6 +21,11 @@ class GitReleasePluginTests extends Specification {
         exec(false, [:], testDir, 'git', 'clone', remoteRepo.canonicalPath, 'GitReleasePluginTestLocal')
 
         project = ProjectBuilder.builder().withName("GitReleasePluginTest").withProjectDir(localRepo).build()
+        
+        ['user.email':'some@some.com', 'user.name':'someone'].each {k, v ->
+            exec(true, [:], localRepo, 'git', 'config', k, v)
+        }
+
         project.version = "1.1"
         project.apply plugin: ReleasePlugin
 


### PR DESCRIPTION
Sometimes git can't properly detect --global user settings => some of tests fail (`** Please tell me who you are...`)

Well, specifying user settings directly fixes that issue.