### PR TITLE
Add configuration to remove hyphen from tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Below are some properties of the Release Plugin Convention that can be used to c
 		<td>Prefixes tag name when release tag is created. Useful when you want the tag to include project name or some other prefix.</td>
 	</tr>
 	<tr>
+		<td>includeHyphenInTag</td>
+		<td>true</td>
+		<td>Uses a hyphen to separate the tagPrefix from the version.</td>
+	</tr>
+	<tr>
 		<td>preCommitText</td>
 		<td></td>
 		<td>This will be prepended to all commits done by the plugin. A good place for code review, or ticket numbers</td>

--- a/src/main/groovy/net/researchgate/release/PluginHelper.groovy
+++ b/src/main/groovy/net/researchgate/release/PluginHelper.groovy
@@ -209,7 +209,11 @@ class PluginHelper {
 
 
 	String tagName() {
-		String prefix = releaseConvention().tagPrefix ? "${releaseConvention().tagPrefix}-" : (releaseConvention().includeProjectNameInTag ? "${project.rootProject.name}-" : "")
+        String prefix;
+        if(releaseConvention().tagPrefix)
+            prefix = releaseConvention().includeHyphenInTag ? "${releaseConvention().tagPrefix}-" : releaseConvention().tagPrefix
+        else
+            prefix = releaseConvention().includeProjectNameInTag ? "${project.rootProject.name}-" : ""
 		return "${prefix}${project.version}"
 	}
 

--- a/src/main/groovy/net/researchgate/release/ReleasePluginConvention.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePluginConvention.groovy
@@ -27,6 +27,8 @@ class ReleasePluginConvention {
 	 */
 	boolean includeProjectNameInTag = false
 
+    boolean includeHyphenInTag = true
+
 	def requiredTasks = []
 	def versionPatterns = [
 			// Increments last number: "2.5-SNAPSHOT" => "2.6-SNAPSHOT"

--- a/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
+++ b/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
@@ -39,4 +39,17 @@ public class PluginHelperTagNameTests extends Specification {
         where:
         includeProjectName << [true, false]
     }
+
+    def 'when includeHyphenInTag is false and tagPrefix not blank then add it to tag without a hyphen separating it'() {
+        given:
+        project.release {
+            includeProjectNameInTag = includeProjectName
+            tagPrefix = 'PREF'
+            includeHyphenInTag = false
+        }
+        expect:
+        tagName() == 'PREF1.1'
+        where:
+        includeProjectName << [true, false]
+    }
 }


### PR DESCRIPTION
The current behavior of this plugin is to include a hyphen between the tagPrefix and the version. We prefer to not have that hyphen to keep consistency among all of our projects.

These commits add a new configuration option - includeHyphenInTag. The default value is true, which is how the plugin works now. The value may be set to false and there will be no hyphen between the tagPrefix and the version.

I chose to make this a configuration option so that existing users of the plugin have the same behavior as before.