### PR TITLE
Expose baseScm so that ReleasePlugin can be subclassed

### DIFF
--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -21,7 +21,7 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
 	static final String RELEASE_GROUP = "Release"
 
 	@SuppressWarnings('StatelessClass')
-	private BaseScmPlugin scmPlugin
+	BaseScmPlugin scmPlugin
 
 	void apply(Project project) {
 		this.project = project


### PR DESCRIPTION
Subclassing of `ReleasePlugin` could be used to adjust the logic in ways that don't have a defined extension point but this presently isn't an option due to private visibility of baseScm and the resolution in some of the closures (line 90).