### PR TITLE
Added tagTemplate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Below are some properties of the Release Plugin Convention that can be used to c
 		<th>Description</th>
 	</tr>
 	<tr>
-		<td>tagPrefix</td>
-		<td></td>
-		<td>Prefixes tag name when release tag is created. Useful when you want the tag to include project name or some other prefix.</td>
+		<td>tagTemplate</td>
+		<td>$version</td>
+		<td>The string template which is used to generate the tag name. Possible variables are $version and $name. Example: "$name-$version" will result in "myproject-1.1.0"</td>
 	</tr>
 	<tr>
 		<td>preCommitText</td>

--- a/src/main/groovy/net/researchgate/release/PluginHelper.groovy
+++ b/src/main/groovy/net/researchgate/release/PluginHelper.groovy
@@ -1,5 +1,6 @@
 package net.researchgate.release
 
+import groovy.text.SimpleTemplateEngine
 import org.apache.tools.ant.BuildException
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -207,10 +208,23 @@ class PluginHelper {
 		}
 	}
 
-
 	String tagName() {
-		String prefix = releaseConvention().tagPrefix ? "${releaseConvention().tagPrefix}-" : (releaseConvention().includeProjectNameInTag ? "${project.rootProject.name}-" : "")
-		return "${prefix}${project.version}"
+        def options = releaseConvention()
+        def tagName
+        if (options.tagTemplate) {
+            def engine = new SimpleTemplateEngine()
+            def binding = [
+                "version": project.version,
+                "name"   : project.rootProject.name
+            ]
+            tagName = engine.createTemplate(options.tagTemplate).make(binding).toString()
+        } else {
+            // Backward compatible remove in version 3.0
+            String prefix = options.tagPrefix ? "${options.tagPrefix}-" : (options.includeProjectNameInTag ? "${project.rootProject.name}-" : "")
+            tagName = "${prefix}${project.version}"
+        }
+
+        tagName
 	}
 
 	String findProperty(String key, String defaultVal = "") {

--- a/src/main/groovy/net/researchgate/release/ReleasePluginConvention.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePluginConvention.groovy
@@ -22,10 +22,25 @@ class ReleasePluginConvention {
 	String newVersionCommitMessage = "[Gradle Release Plugin] - new version commit: "
 
 	/**
-	 * If true, tag names and messages will include the project name (e.g. project-name-version)
-	 * otherwise only version is used.
+	 * @deprecated to be removed in 3.0 see tagTemplate
 	 */
+    @Deprecated
 	boolean includeProjectNameInTag = false
+
+    /**
+     * @deprecated to be removed in 3.0 see tagTemplate
+     */
+    @Deprecated
+    String tagPrefix = null
+
+    /**
+     * Custom template for the tag
+     * Possible template variables are $version and $name
+     * example "$name-$version" -> "myproject-1.1"
+     *
+     * as of 3.0 set this to "$version" by default
+     */
+    String tagTemplate = null
 
 	def requiredTasks = []
 	def versionPatterns = [
@@ -37,7 +52,6 @@ class ReleasePluginConvention {
 
     String versionPropertyFile = 'gradle.properties'
     def versionProperties = []
-    String tagPrefix = null
 
 	void release(Closure closure) {
 		closure.delegate = this

--- a/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
+++ b/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
@@ -39,4 +39,27 @@ public class PluginHelperTagNameTests extends Specification {
         where:
         includeProjectName << [true, false]
     }
+
+    def 'when tagTemplate not blank then it is used as tag name and all other options are ignored'() {
+        given:
+        project.release {
+            tagTemplate = '$version'
+            tagPrefix = tagPrefixSetting
+            includeProjectNameInTag = includeProjectName
+        }
+        expect:
+        tagName() == '1.1'
+        where:
+        includeProjectName << [true, false]
+        tagPrefixSetting << ['PREF', null]
+    }
+
+    def 'when tagTemplate not blank then it is used as tag name'() {
+        given:
+        project.release {
+            tagTemplate = 'PREF-$name-$version'
+        }
+        expect:
+        tagName() == 'PREF-ReleasePluginTest-1.1'
+    }
 }


### PR DESCRIPTION
This allows setting tagTemplate in the configuration. tagTemplate is a string that gets evaluated as a template. Possible values are $version and $name.
So it might look something like:
"$version" -> 1.0.0
"v$version" -> v1.0.0
"$name-$version" -> project-1.0.0
"custom-$version" -> custom-1.0.0

Also deprecated tagPrefix and includeProjectNameInTag configurations.