### PR TITLE
Allow external scm plugins

### DIFF
--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -287,17 +287,21 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
 	 * @param directory the directory to start from
 	 */
 	protected Class findScmType(File directory) {
-
-		Class c = (Class) directory.list().with {
-			delegate.grep('.svn') ? SvnReleasePlugin :
-				delegate.grep('.bzr') ? BzrReleasePlugin :
-					delegate.grep('.git') ? GitReleasePlugin :
+		Class c
+		if (releaseConvention().customScmPlugin) {
+			c = releaseConvention().customScmPlugin
+		} else {
+			c = (Class) directory.list().with {
+				delegate.grep('.git') ? GitReleasePlugin :
+					delegate.grep('.svn') ? SvnReleasePlugin :
 						delegate.grep('.hg') ? HgReleasePlugin :
-							null
-		}
+							delegate.grep('.bzr') ? BzrReleasePlugin :
+								null
+			}
 
-		if (!c && directory.parentFile) {
-			c = findScmType(directory.parentFile)
+			if (!c && directory.parentFile) {
+				c = findScmType(directory.parentFile)
+			}
 		}
 
 		c

--- a/src/main/groovy/net/researchgate/release/ReleasePluginConvention.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePluginConvention.groovy
@@ -53,6 +53,8 @@ class ReleasePluginConvention {
     String versionPropertyFile = 'gradle.properties'
     def versionProperties = []
 
+	Class<BaseScmPlugin> customScmPlugin = null
+
 	void release(Closure closure) {
 		closure.delegate = this
 		closure.call()

--- a/src/test/groovy/net/researchgate/release/ReleasePluginCheckCustomSCMPluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginCheckCustomSCMPluginTests.groovy
@@ -1,0 +1,26 @@
+package net.researchgate.release
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+public class ReleasePluginCheckCustomSCMPluginTests extends Specification {
+
+    def project
+
+    def setup() {
+        project = ProjectBuilder.builder().withName("ReleasePluginTest").build()
+        project.apply plugin: ReleasePlugin
+        project.release {
+            customScmPlugin = NoSCMReleasePlugin
+        }
+        project.findScmPlugin.execute()
+    }
+
+    def 'when setting a customScmPlugin it should be accepted'() {
+        when:
+        project.createReleaseTag.execute()
+        then:
+        notThrown GradleException
+    }
+}


### PR DESCRIPTION
Add a property to the convention so other users can use there own scm plugins.

Also changed the order of scm types as I think git > svn > hg > bzr should be more accurate nowadays.