### PR TITLE
support for creating intermediate directories with SVN tagging

### DIFF
--- a/src/main/groovy/net/researchgate/release/SvnAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/SvnAdapter.groovy
@@ -137,7 +137,7 @@ class SvnAdapter extends BaseScmAdapter {
         String svnRoot = props.releaseSvnRoot
         String svnTag = tagName()
 
-        svnExec(['cp', "${svnUrl}@${svnRev}", "${svnRoot}/tags/${svnTag}", '-m', message])
+        svnExec(['cp', "${svnUrl}@${svnRev}", "${svnRoot}/tags/${svnTag}", '--parents', '-m', message])
     }
 
     @Override


### PR DESCRIPTION
Currently we make use of a directory structure within our SVN 'tags' directory. Hereby we create some subdirectories based on major and major.minor versions of our tags. We can now achieve this behavior with the tagTemplate option (at least partly). 

Some examples:
```
/tags/1/1.20/1.20.1.5
```

Corresponding tag template:
```
'${ version.tokenize(".")[0] }/${ version.tokenize(".")[0] + "." + version.tokenize(".")[1] }/${version}'
```

The caveat is that SVN does not create the intermediate directories by default, therefore we need the `--parents` option, which is where this pull request is for.