### PR TITLE
support subprojects with different versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,13 +211,13 @@ For example, if we wanted to make sure `uploadArchives` is called and succeeds a
 
 ### Multi-Project Builds
 
-Support for [multi-project builds](http://gradle.org/docs/current/userguide/multi_project_builds.html) isn't complete, but will work given some assumptions. The gradle-release plugin assumes and expects the following:
+Support for [multi-project builds](http://gradle.org/docs/current/userguide/multi_project_builds.html) isn't complete, but will work given some assumptions. The gradle-release plugin assumes and expects that only one version control system is used by both root and sub projects.
 
-1. Only the root|parent project is applying the plugin
-2. Only one version is used for root and sub projects
-3. Only one version control system is used by both root and sub projects
+Apply the plugin separately to each subproject that you wish to release. Release using a qualified task name, e.g.:
 
-This means the gradle-release plugin does not support sub projects that have different versions from their parent|root project, and it does not support sub projects that have different version control systems from the parent project.
+    ./gradlew :sub:release # release a subproject named "sub"
+    ./gradlew :release # release the root project
+
 
 ### Working in Continuous Integration
 

--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -40,32 +40,36 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
         project.task('release', description: 'Verify project, release, and update version to next.', group: RELEASE_GROUP, type: GradleBuild) {
             startParameter = project.getGradle().startParameter.newInstance()
 
+            // name tasks with an absolute path so subprojects can be released independently
+            def p = project.getPath()
+            if (!p.endsWith(Project.PATH_SEPARATOR)) p += Project.PATH_SEPARATOR
+
             tasks = [
-                    'createScmAdapter',
+                    "${p}createScmAdapter" as String,
                     //  0. (This Plugin) Initializes the corresponding SCM plugin (Git/Bazaar/Svn/Mercurial).
-                    'initScmAdapter',
+                    "${p}initScmAdapter" as String,
                     //  1. (SCM Plugin) Check to see if source needs to be checked in.
-                    'checkCommitNeeded',
+                    "${p}checkCommitNeeded" as String,
                     //  2. (SCM Plugin) Check to see if source is out of date
-                    'checkUpdateNeeded',
+                    "${p}checkUpdateNeeded" as String,
                     //  3. (This Plugin) Update Snapshot version if used
                     //     Needs to be done before checking for snapshot versions since the project might depend on other
                     //     Modules within the same project.
-                    'unSnapshotVersion',
+                    "${p}unSnapshotVersion" as String,
                     //  4. (This Plugin) Confirm this release version
-                    'confirmReleaseVersion',
+                    "${p}confirmReleaseVersion" as String,
                     //  5. (This Plugin) Check for SNAPSHOT dependencies if required.
-                    'checkSnapshotDependencies',
+                    "${p}checkSnapshotDependencies" as String,
                     //  6. (This Plugin) Build && run Unit tests
-                    'runBuildTasks',
+                    "${p}runBuildTasks" as String,
                     //  7. (This Plugin) Commit Snapshot update (if done)
-                    'preTagCommit',
+                    "${p}preTagCommit" as String,
                     //  8. (SCM Plugin) Create tag of release.
-                    'createReleaseTag',
+                    "${p}createReleaseTag" as String,
                     //  9. (This Plugin) Update version to next version.
-                    'updateVersion',
+                    "${p}updateVersion" as String,
                     // 10. (This Plugin) Commit version update.
-                    'commitNewVersion'
+                    "${p}commitNewVersion" as String
             ]
         }
 
@@ -94,10 +98,14 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
         project.task('runBuildTasks', group: RELEASE_GROUP, description: 'Runs the build process in a separate gradle run.', type: GradleBuild) {
             startParameter = project.getGradle().startParameter.newInstance()
 
+            // name tasks with an absolute path so subprojects can be released independently
+            def p = project.getPath()
+            if (!p.endsWith(Project.PATH_SEPARATOR)) p += Project.PATH_SEPARATOR
+
             tasks = [
-                'beforeReleaseBuild',
-                'build',
-                'afterReleaseBuild'
+                "${p}beforeReleaseBuild" as String,
+                "${p}build" as String,
+                "${p}afterReleaseBuild" as String
             ]
         }
 

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginIntegrationTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginIntegrationTests.groovy
@@ -39,12 +39,12 @@ class GitReleasePluginIntegrationTests extends GitSpecification {
         localGit.push().setForce(true).call()
         when: 'calling release task indirectly'
         project.tasks['release'].tasks.each { task ->
-            if (task == "runBuildTasks") {
-                project.tasks[task].tasks.each { buildTask ->
-                    project.tasks[buildTask].execute()
+            if (task == ":runBuildTasks") {
+                project.tasks.getByPath(task).tasks.each { buildTask ->
+                    project.tasks.getByPath(buildTask).execute()
                 }
             } else {
-                project.tasks[task].execute()
+                project.tasks.getByPath(task).execute()
             }
         }
         def st = localGit.status().call()

--- a/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
@@ -48,4 +48,13 @@ class ReleasePluginTests extends Specification {
         project.version == '1.2'
 
     }
+
+    def 'subproject tasks are named with qualified paths'() {
+        given:
+        Project sub = ProjectBuilder.builder().withName('sub').withParent(project).withProjectDir(testDir).build()
+        sub.apply plugin: ReleasePlugin
+
+        expect:
+        sub.tasks.release.tasks.every { it.startsWith(':sub:') }
+    }
 }


### PR DESCRIPTION
Generates `release` task list with fully-qualified task names, allowing
you to run the `release` task on a single subproject at a time. Expects
you to apply the plugin seperately to each subproject.

Note: this may mean that subprojects can have different VCS, but I
haven't tested that.