### PR TITLE
Setting requireBranch property to a regular expressions #118

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Below are some properties of the Release Plugin Convention that are specific to 
 		<td>Git</td>
 		<td>requireBranch</td>
 		<td>master</td>
-		<td>Defines the branch which releases must be done off of. Eg. set to `release` to require releases are done on the `release` branch. Set to '' to ignore.</td>
+		<td>Defines the branch which releases must be done off of. Eg. set to `release` to require releases are done on the `release` branch (or use a regular expression to allow releases from multiple branches, e.g. `/release|master/`). Set to '' to ignore.</td>
 	</tr>
 </table>
 

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -52,7 +52,7 @@ class GitAdapter extends BaseScmAdapter {
     void init() {
         if (extension.git.requireBranch) {
             def branch = gitCurrentBranch()
-            if (branch != extension.git.requireBranch) {
+            if (!(branch ==~ extension.git.requireBranch)) {
                 throw new GradleException("Current Git branch is \"$branch\" and not \"${ extension.git.requireBranch }\".")
             }
         }

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
@@ -70,6 +70,15 @@ class GitReleasePluginTests extends Specification {
         ex.message == 'Current Git branch is "master" and not "myBranch".'
     }
 
+    def 'when requireBranch is configured using a regex that matches current branch then don\'t throw exception'() {
+        given:
+        project.release.git.requireBranch = /myBranch|master/
+        when:
+        (new GitAdapter(project)).init()
+        then:
+        noExceptionThrown()
+    }
+
     def 'should accept config as closure'() {
         when:
         project.release {


### PR DESCRIPTION
Added a fix to allow setting a regular expression as a value for the release.git.requireBranch property