### PR TITLE
Automatically version based on semver rules.

### DIFF
--- a/src/main/groovy/net/researchgate/release/BaseScmAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/BaseScmAdapter.groovy
@@ -34,4 +34,6 @@ abstract class BaseScmAdapter extends PluginHelper {
     abstract void commit(String message)
 
     abstract void revert()
+	
+	abstract String assignReleaseVersionAutomatically(String currentVersion)
 }

--- a/src/main/groovy/net/researchgate/release/BzrAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/BzrAdapter.groovy
@@ -124,4 +124,9 @@ class BzrAdapter extends BaseScmAdapter {
     void revert() {
         exec(['bzr', 'revert', findPropertiesFile().name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
     }
+	
+	@Override
+	String assignReleaseVersionAutomatically(String currentVersion) {
+		throw new GradleException("Method not implemented yet.")
+	}
 }

--- a/src/main/groovy/net/researchgate/release/HgAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/HgAdapter.groovy
@@ -10,6 +10,7 @@
 
 package net.researchgate.release
 
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 
 class HgAdapter extends BaseScmAdapter {
@@ -97,4 +98,9 @@ class HgAdapter extends BaseScmAdapter {
     private String hgCurrentBranch() {
         exec(['hg', 'branch']).readLines()[0]
     }
+	
+	@Override
+	String assignReleaseVersionAutomatically(String currentVersion) {
+		throw new GradleException("Method not implemented yet.")
+	}
 }

--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -175,6 +175,7 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
         String releaseVersion = project.properties['releaseVersion']
 
         if (useAutomaticVersion()) {
+			releaseVersion = scmAdapter.assignReleaseVersionAutomatically(candidateVersion)
             return releaseVersion ?: candidateVersion
         }
 

--- a/src/main/groovy/net/researchgate/release/SemanticVersion.java
+++ b/src/main/groovy/net/researchgate/release/SemanticVersion.java
@@ -1,0 +1,124 @@
+package net.researchgate.release;
+
+public class SemanticVersion {
+
+	/** The major version of the application that are not backwards compatible. */
+	private final int major;
+	/** The minor version of the application that represents features. */
+	private final int minor;
+	/** Patches to the feature version. */
+	private final int patch;
+
+	/**
+	 * @param major The major version of the application that are not backwards compatible.
+	 * @param minor The minor version of the application that represents features.
+	 * @param patch Patches to the feature version.
+	 */
+	public SemanticVersion(final int major, final int minor, final int patch) {
+		this.major = major;
+		this.minor = minor;
+		this.patch = patch;
+	}
+
+	public SemanticVersion(final String version) {
+		String releaseVersion = version;
+		if (isSnapshot(version)) {
+			releaseVersion = releaseVersion.substring(0,
+					releaseVersion.indexOf("-SNAPSHOT"));
+		}
+		String[] semanticVersion = releaseVersion.split("\\.");
+		if (semanticVersion.length != 3) {
+			throw new IllegalArgumentException(
+					"Semantic version should have 3 digits and be in the format x.x.x");
+		}
+		this.major = Integer.parseInt(semanticVersion[0]);
+		this.minor = Integer.parseInt(semanticVersion[1]);
+		this.patch = Integer.parseInt(semanticVersion[2]);
+	}
+
+	private boolean isSnapshot(final String version) {
+		return version.contains("-SNAPSHOT");
+	}
+
+	/**
+	 * @return the major
+	 */
+	public final int getMajor() {
+		return major;
+	}
+
+	/**
+	 * @return the minor
+	 */
+	public final int getMinor() {
+		return minor;
+	}
+
+	/**
+	 * @return the patch
+	 */
+	public final int getPatch() {
+		return patch;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + major;
+		result = prime * result + minor;
+		result = prime * result + patch;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		SemanticVersion other = (SemanticVersion) obj;
+		if (major != other.major) {
+			return false;
+		}
+		if (minor != other.minor) {
+			return false;
+		}
+		if (patch != other.patch) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @return The version that has the new feature.
+	 */
+	public SemanticVersion newFeature() {
+		return new SemanticVersion(this.major, this.minor + 1, 0);
+	}
+
+	/**
+	 * @return The version that has the new patch.
+	 */
+	public SemanticVersion newPatch() {
+		return new SemanticVersion(this.major, this.minor, this.patch + 1);
+	}
+
+	/**
+	 * @return The version that has the new major change.
+	 */
+	public SemanticVersion newMajor() {
+		return new SemanticVersion(this.major + 1, 0, 0);
+	}
+
+	@Override
+	public String toString() {
+		return major + "." + minor + "." + patch;
+	}
+
+}

--- a/src/main/groovy/net/researchgate/release/SvnAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/SvnAdapter.groovy
@@ -209,4 +209,9 @@ class SvnAdapter extends BaseScmAdapter {
             throw new GradleException('Could not determine root SVN url or revision.')
         }
     }
+	
+	@Override
+	String assignReleaseVersionAutomatically(String currentVersion) {
+		throw new GradleException("Method not implemented yet.")
+	}
 }

--- a/src/test/groovy/net/researchgate/release/AutomaticSemanticVersioningTests.groovy
+++ b/src/test/groovy/net/researchgate/release/AutomaticSemanticVersioningTests.groovy
@@ -1,0 +1,132 @@
+/*
+ * This file is part of the gradle-release plugin.
+ *
+ * (c) Eric Berry
+ * (c) ResearchGate GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+package net.researchgate.release
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+
+class AutomaticSemanticVersioningTests extends GitSpecification {
+
+    Project project
+
+    PluginHelper helper
+
+    def setup() {
+        project = ProjectBuilder.builder().withName("GitReleasePluginTest").withProjectDir(localGit.repository.workTree).build()
+        project.apply plugin: ReleasePlugin
+        project.createScmAdapter.execute()
+
+        helper = new PluginHelper(project: project, extension: project.extensions['release'] as ReleaseExtension)
+    }
+	
+	def cleanup() {
+		localGit.tagDelete().setTags("1.0.0").call()
+	}
+
+    def 'feature version should be incremented when no previous tags exist based on project version'() {
+        given:
+        project.version = '1.0.0-SNAPSHOT' 
+		project.setProperty('release.useAutomaticVersion',  "true")
+		gitAdd(localGit, 'modified.txt') { it << "version=$project.version" }
+		gitCommit(localGit, 'Merge branch \'feature-JIRA-1\' into \'master\'')
+        when:
+        project.confirmReleaseVersion.execute()
+        then:
+		project.version == '1.1.0'
+    }
+	
+	def 'patch version should be incremented when no previous tags exist based on project version'() {
+		given:
+		project.version = '1.0.0-SNAPSHOT'
+		project.setProperty('release.useAutomaticVersion',  "true")
+		gitAdd(localGit, 'modified.txt') { it << "version=$project.version" }
+		gitCommit(localGit, 'Merge branch \'patch-JIRA-1\' into \'master\'')
+		when:
+		project.confirmReleaseVersion.execute()
+		then:
+		project.version == '1.0.1'
+	}
+	
+	def 'major version should be incremented when no previous tags exist based on project version'() {
+		given:
+		project.version = '1.0.0-SNAPSHOT'
+		project.setProperty('release.useAutomaticVersion',  "true")
+		gitAdd(localGit, 'modified.txt') { it << "version=$project.version" }
+		gitCommit(localGit, 'Merge branch \'major-JIRA-1\' into \'master\'')
+		when:
+		project.confirmReleaseVersion.execute()
+		then:
+		project.version == '2.0.0'
+	}
+
+    def 'feature version should be incremented based on last tag version'() {
+        given:
+        project.version = '1.0.0'
+        localGit.tag().setName(helper.tagName()).call()
+		
+		project.version = '1.0.1'
+		project.setProperty('release.useAutomaticVersion',  "true")
+		gitAdd(localGit, 'modified.txt') { it << "version=$project.version" }
+		gitCommit(localGit, 'Merge branch \'feature-JIRA-1\' into \'master\'')
+        when:
+        project.confirmReleaseVersion.execute()
+        then:
+        project.version == '1.1.0'
+    }
+	
+	def 'patch version should be incremented based on last tag version'() {
+		given:
+		project.version = '1.0.0'
+		localGit.tag().setName(helper.tagName()).call()
+		
+		project.version = '1.0.1'
+		project.setProperty('release.useAutomaticVersion',  "true")
+		gitAdd(localGit, 'modified.txt') { it << "version=$project.version" }
+		gitCommit(localGit, 'Merge branch \'patch-JIRA-1\' into \'master\'')
+		when:
+		project.confirmReleaseVersion.execute()
+		then:
+		project.version == '1.0.1'
+	}
+	
+	def 'major version should be incremented based on last tag version'() {
+		given:
+		project.version = '1.0.0'
+		localGit.tag().setName(helper.tagName()).call()
+		
+		project.version = '1.0.1'
+		project.setProperty('release.useAutomaticVersion',  "true")
+		gitAdd(localGit, 'modified.txt') { it << "version=$project.version" }
+		gitCommit(localGit, 'Merge branch \'major-JIRA-1\' into \'master\'')
+		when:
+		project.confirmReleaseVersion.execute()
+		then:
+		project.version == '2.0.0'
+	}
+	
+	def 'cant version because there is no enough information on last commit message'() {
+		given:
+		project.version = '1.0.0'
+		localGit.tag().setName(helper.tagName()).call()
+		
+		project.version = '1.0.1'
+		project.setProperty('release.useAutomaticVersion',  "true")
+		gitAdd(localGit, 'modified.txt') { it << "version=$project.version" }
+		gitCommit(localGit, 'something different from a branch merge')
+		when:
+		project.confirmReleaseVersion.execute()
+		then:
+		GradleException ex = thrown()
+		ex.cause.message.contains "Could not assign release version automatically"
+	}
+	
+}

--- a/src/test/groovy/net/researchgate/release/GitSpecification.groovy
+++ b/src/test/groovy/net/researchgate/release/GitSpecification.groovy
@@ -35,6 +35,10 @@ abstract class GitSpecification extends Specification {
         gitAdd(git, name, content)
         git.commit().setAll(true).setMessage("commit $name").call()
     }
+	
+	static void gitCommit(Git git, String commitMessage) {
+		git.commit().setAll(true).setMessage(commitMessage).call()
+	}
 
     static void gitHardReset(Git git) {
         git.reset().setMode(HARD).setRef(HEAD).call()

--- a/src/test/groovy/net/researchgate/release/NoSCMReleaseAdapter.groovy
+++ b/src/test/groovy/net/researchgate/release/NoSCMReleaseAdapter.groovy
@@ -57,4 +57,9 @@ class NoSCMReleaseAdapter extends BaseScmAdapter {
     void revert() {
         //To change body of implemented methods use File | Settings | File Templates.
     }
+	
+	@Override
+	String assignReleaseVersionAutomatically(String currentVersion) {
+		//
+	}
 }

--- a/src/test/groovy/net/researchgate/release/SemanticVersionTest.java
+++ b/src/test/groovy/net/researchgate/release/SemanticVersionTest.java
@@ -1,0 +1,118 @@
+/**
+ * 
+ */
+package net.researchgate.release;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author gus
+ *
+ */
+public class SemanticVersionTest {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+	
+	@Test
+	public final void parseValidReleaseVersion() {
+		SemanticVersion version = new SemanticVersion("1.0.0");
+		Assert.assertEquals(1, version.getMajor());
+		Assert.assertEquals(0, version.getMinor());
+		Assert.assertEquals(0, version.getPatch());
+	}
+	
+	@Test
+	public final void parseValidSnapshotVersion() {
+		SemanticVersion version = new SemanticVersion("1.0.0-SNAPSHOT");
+		Assert.assertEquals(1, version.getMajor());
+		Assert.assertEquals(0, version.getMinor());
+		Assert.assertEquals(0, version.getPatch());
+	}
+	
+	@Test
+	public final void parseInvalidSemanticVersion() {
+		expectedException.expect(IllegalArgumentException.class);
+		new SemanticVersion("1.0");
+	}
+	
+	@Test
+	public final void parseInvalidVersion() {
+		expectedException.expect(NumberFormatException.class);
+		new SemanticVersion("1.0.0-RC");
+	}
+	
+	@Test
+	public final void parseSemanticVersionWithDashesInsteadOfPoints() {
+		expectedException.expect(IllegalArgumentException.class);
+		new SemanticVersion("1-0-0");
+	}
+	
+	@Test
+	public final void twoInstancesAreEqual() {
+		SemanticVersion v1 = new SemanticVersion(1, 0, 0);
+		SemanticVersion v2 = new SemanticVersion("1.0.0");
+		Assert.assertEquals(v1, v2);
+	}
+	
+	@Test
+	public final void incrementMinorVersion() {
+		SemanticVersion version = new SemanticVersion(1, 0, 0);
+		SemanticVersion newVersion = version.newFeature();
+		Assert.assertEquals(1, version.getMajor());
+		Assert.assertEquals(0, version.getMinor());
+		Assert.assertEquals(0, version.getPatch());
+		
+		Assert.assertEquals(1, newVersion.getMajor());
+		Assert.assertEquals(1, newVersion.getMinor());
+		Assert.assertEquals(0, newVersion.getPatch());
+	}
+	
+	@Test
+	public final void incrementMinorVersionWhenPatchesExist() {
+		SemanticVersion version = new SemanticVersion(1, 0, 4);
+		SemanticVersion newVersion = version.newFeature();
+		Assert.assertEquals(1, version.getMajor());
+		Assert.assertEquals(0, version.getMinor());
+		Assert.assertEquals(4, version.getPatch());
+		
+		Assert.assertEquals(1, newVersion.getMajor());
+		Assert.assertEquals(1, newVersion.getMinor());
+		Assert.assertEquals(0, newVersion.getPatch());
+	}
+	
+	@Test
+	public final void incrementPatchVersion() {
+		SemanticVersion version = new SemanticVersion(1, 0, 0);
+		SemanticVersion newVersion = version.newPatch();
+		Assert.assertEquals(1, version.getMajor());
+		Assert.assertEquals(0, version.getMinor());
+		Assert.assertEquals(0, version.getPatch());
+		
+		Assert.assertEquals(1, newVersion.getMajor());
+		Assert.assertEquals(0, newVersion.getMinor());
+		Assert.assertEquals(1, newVersion.getPatch());
+	}
+	
+	@Test
+	public final void incrementMajorVersionWhenFeaturesAndPatchesExist() {
+		SemanticVersion version = new SemanticVersion(1, 2, 3);
+		SemanticVersion newVersion = version.newMajor();
+		Assert.assertEquals(1, version.getMajor());
+		Assert.assertEquals(2, version.getMinor());
+		Assert.assertEquals(3, version.getPatch());
+		
+		Assert.assertEquals(2, newVersion.getMajor());
+		Assert.assertEquals(0, newVersion.getMinor());
+		Assert.assertEquals(0, newVersion.getPatch());
+	}
+	
+	@Test
+	public final void convertToString() {
+		String version = "1.0.0";
+		Assert.assertEquals(version, new SemanticVersion(version).toString());
+	}
+}


### PR DESCRIPTION
This feature depends on how branches are named. For instance, if the
branch merged into master has one of the following prefixes: major-,
feature-, or patch-, the plugin will automatically set the project
version without any human interaction.

The motivation behind is to version automatically using semver rules without human interaction at release time and perhaps leaving this job, versioning, to a CI tool