### PR TITLE
Add a pushToBranchPrefix option to git adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * COMMON: Fixed internal bug in Executor not overwritting environment variables as expected (#135, thanks ddimtirov)
 * COMMON: Fix bug with projects that do not yet have a property file created (#123, thanks dodgex) 
 * GIT: The option ```pushToCurrentBranch``` is deprecated, as it was simply unnecessary
+* GIT: Option ```pushToBranchPrefix``` can now be set to specify a remote branch prefix when committing next version
 
 ## 2.2.2
 ##### Released: 8. September 2015

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ release {
         requireBranch = 'master'
         pushToRemote = 'origin'
         pushToCurrentBranch = false
+        pushToBranchPrefix = ''
     }
 
     svn {

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -31,6 +31,7 @@ class GitAdapter extends BaseScmAdapter {
         /** @deprecated Remove in version 3.0 */
         @Deprecated
         boolean pushToCurrentBranch = false
+        String pushToBranchPrefix
     }
 
     GitAdapter(Project project, Map<String, Object> attributes) {
@@ -104,7 +105,11 @@ class GitAdapter extends BaseScmAdapter {
     void commit(String message) {
         exec(['git', 'commit', '-a', '-m', message], errorPatterns: ['error: ', 'fatal: '])
         if (shouldPush()) {
-            exec(['git', 'push', '--porcelain', extension.git.pushToRemote, gitCurrentBranch()], errorMessage: 'Failed to push to remote', errorPatterns: ['[rejected]', 'error: ', 'fatal: '])
+            def branch = gitCurrentBranch()
+            if (extension.git.pushToBranchPrefix) {
+                branch = "HEAD:${extension.git.pushToBranchPrefix}${branch}"
+            }
+            exec(['git', 'push', '--porcelain', extension.git.pushToRemote, branch], errorMessage: 'Failed to push to remote', errorPatterns: ['[rejected]', 'error: ', 'fatal: '])
         }
     }
 


### PR DESCRIPTION
When using a review system like gerrit, commits are pushed to
special branches. Instead of pushing simply to 'master', one
needs to push to 'refs/for/master'.
An option 'pushToBranchPrefix' was added to the git adapter to
be able to achieve this.