### PR TITLE
Fixed update version problem that updated all props ending in "version"

### DIFF
--- a/src/main/groovy/net/researchgate/release/PluginHelper.groovy
+++ b/src/main/groovy/net/researchgate/release/PluginHelper.groovy
@@ -96,8 +96,8 @@ class PluginHelper {
             } else {
                 // we use replace here as other ant tasks escape and modify the whole file
                 project.ant.replaceregexp(file: file, byline: true) {
-                    regexp(pattern: "$key(\\s*)=(\\s*).+")
-                    substitution(expression: "$key\\1=\\2$version")
+                    regexp(pattern: "^(\\s*)$key(\\s*)=(\\s*).+")
+                    substitution(expression: "\\1$key\\2=\\3$version")
                 }
             }
         } catch (BuildException be) {

--- a/src/test/groovy/net/researchgate/release/PluginHelperVersionPropertyFileTests.groovy
+++ b/src/test/groovy/net/researchgate/release/PluginHelperVersionPropertyFileTests.groovy
@@ -118,6 +118,7 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
         props.withWriter {
             it << "version=${project.version}\n"
             it << "something=http://www.gradle.org/test\n"
+            it << "  another.prop.version =  1.1\n"
         }
         project.createScmAdapter.execute()
         when:
@@ -128,5 +129,6 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
         noExceptionThrown()
         lines[0] == 'version=3.1'
         lines[1] == 'something=http://www.gradle.org/test'
+        lines[2] == '  another.prop.version =  1.1'
     }
 }


### PR DESCRIPTION
The current version has a bug when releasing with automatic update of the version where all properties in gradle.properties that end in "version" get updated with the new version.

I.e. For properties defined as:
  version=1.1-SNAPSHOT
  another.lib.version=5.0
Both properties get a new version of 1.2-SNAPSHOT

This branch fixes the issue and includes a test that exposes the issue if the fix is not applied.
