### PR TITLE
An option 'commitVersionFileOnly' will be useful when we want to avoid build server script changing git indexed file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.3.5
+#####
+
+### New Features
+
+* GIT: Option ```commitVersionFileOnly``` can now be set to make sure we only commit the versionFile instead of all modified file.
+    * This will be useful in some case when the repository is modified by the build job on some files to work around build server limitation.
+
 ## 2.3.4
 ##### Released: 5. October 2015
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ release {
         requireBranch = 'master'
         pushToRemote = 'origin'
         pushToBranchPrefix = ''
+        commitVersionFileOnly = false
     }
 
     svn {

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -32,6 +32,7 @@ class GitAdapter extends BaseScmAdapter {
         @Deprecated
         boolean pushToCurrentBranch = false
         String pushToBranchPrefix
+        boolean commitVersionFileOnly = false
 
         void setProperty(String name, Object value) {
             if (name == 'pushToCurrentBranch') {
@@ -111,7 +112,12 @@ class GitAdapter extends BaseScmAdapter {
 
     @Override
     void commit(String message) {
-        exec(['git', 'commit', '-a', '-m', message], errorPatterns: ['error: ', 'fatal: '])
+        if (extension.git.commitVersionFileOnly) {
+            exec(['git', 'commit', extension.versionPropertyFile, '-m', message], errorPatterns: ['error: ', 'fatal: '])
+        }
+        else {
+            exec(['git', 'commit', '-a', '-m', message], errorPatterns: ['error: ', 'fatal: '])
+        }
         if (shouldPush()) {
             def branch = gitCurrentBranch()
             if (extension.git.pushToBranchPrefix) {


### PR DESCRIPTION
An option 'commitVersionFileOnly' will be useful when we want to avoid build server script changing git indexed file.

Change-Id: I333b9e0f668deb64b4055db9ef0653540522ae90