### PR TITLE
SVN: support for --pin-externals of SVN 1.9 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ release {
     svn {
         username = null
         password = null
+        pinExternals = false   // allows to pin the externals when tagging, requires subversion client >= 1.9.0
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testCompile("org.spockframework:spock-core:$spockVersion") { exclude group: 'org.codehaus.groovy' }
     testCompile "junit:junit:$junitVersion"
     testCompile "org.eclipse.jgit:org.eclipse.jgit:$jgitVersion"
+    testCompile "cglib:cglib-nodep:$cglibVersion"
 }
 
 plugindev {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ version=2.3.6-SNAPSHOT
 spockVersion=0.7-groovy-1.8
 jgitVersion=3.7.1.201504261725-r
 junitVersion=4.12
+cglibVersion=3.2.0

--- a/src/main/groovy/net/researchgate/release/SvnAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/SvnAdapter.groovy
@@ -34,6 +34,7 @@ class SvnAdapter extends BaseScmAdapter {
     class SvnConfig {
         String username
         String password
+        boolean pinExternals = false
     }
 
     @Override
@@ -135,7 +136,11 @@ class SvnAdapter extends BaseScmAdapter {
         String svnRoot = attributes.svnRoot
         String svnTag = tagName()
 
-        svnExec(['copy', "${svnUrl}@${svnRev}", "${svnRoot}/tags/${svnTag}", '--parents', '-m', message])
+        List<String> commands = ['copy', "${svnUrl}@${svnRev}", "${svnRoot}/tags/${svnTag}", '--parents', '-m', message]
+        if (extension.svn.pinExternals) {
+            commands += '--pin-externals'
+        }
+        svnExec(commands)
     }
 
     @Override

--- a/src/test/groovy/net/researchgate/release/SvnAdapterTests.groovy
+++ b/src/test/groovy/net/researchgate/release/SvnAdapterTests.groovy
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the gradle-release plugin.
+ *
+ * (c) Eric Berry
+ * (c) ResearchGate GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package net.researchgate.release
+
+import net.researchgate.release.cli.Executor
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class SvnAdapterTests extends Specification {
+    Project project
+    SvnAdapter svnAdapter
+
+    def setup() {
+        project = ProjectBuilder.builder().withName('ReleasePluginTest').build()
+        project.apply plugin: ReleasePlugin
+        project.version = '1.0.0'
+
+        svnAdapter = new SvnAdapter(project, [:])
+        svnAdapter.executor = Mock(Executor)
+        svnAdapter.attributes.svnUrl  = 'svn://server/repo'
+        svnAdapter.attributes.svnRev  = 123
+        svnAdapter.attributes.svnRoot = '/root'
+    }
+
+    def "pin externals - default case"() {
+        when:
+        svnAdapter.createReleaseTag("my test tag")
+
+        then:
+        1 * svnAdapter.executor.exec(_, ['svn', 'copy', 'svn://server/repo@123', '/root/tags/1.0.0', '--parents', '-m', 'my test tag'])
+    }
+
+    def "pin externals - disabled"() {
+        given:
+        project.release.svn.pinExternals = false
+
+        when:
+        svnAdapter.createReleaseTag("my test tag")
+
+        then:
+        1 * svnAdapter.executor.exec(_, ['svn', 'copy', 'svn://server/repo@123', '/root/tags/1.0.0', '--parents', '-m', 'my test tag'])
+    }
+
+    def "pin externals - enabled"() {
+        given:
+        project.release.svn.pinExternals = true
+
+        when:
+        svnAdapter.createReleaseTag("my test tag")
+
+        then:
+        1 * svnAdapter.executor.exec(_, ['svn', 'copy', 'svn://server/repo@123', '/root/tags/1.0.0', '--parents', '-m', 'my test tag', '--pin-externals'])
+    }
+}


### PR DESCRIPTION
The new SVN client (v1.9) supports the --pin-externals flag, which allows to fix externals to a specific revision when creating the tag.