### PR TITLE
CLI Executor now detects error from process exitValue

### DIFF
--- a/src/main/groovy/net/researchgate/release/cli/Executor.groovy
+++ b/src/main/groovy/net/researchgate/release/cli/Executor.groovy
@@ -36,7 +36,7 @@ class Executor {
         process.waitForProcessOutput(out, err)
         logger?.info("Running $commands produced output: [${out.toString().trim()}]")
 
-        if (err.toString()) {
+        if (process.exitValue()) {
             def message = "Running $commands produced an error: [${err.toString().trim()}]"
 
             if (options['failOnStderr'] as boolean) {


### PR DESCRIPTION
Some systems will always output messages to stderr. Instead of using this to determine errors, executor should use the process' exit value. Non-zero values are errors.