### PR TITLE
add a new option to the plugin to support other options during push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 .idea
 out
 
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ build
 .idea
 out
 
-/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * GIT: Option `git.commitVersionFileOnly` can now be set to make sure we only commit the versionFile instead of all modified file.
     * This will be useful in some case when the repository is modified by the build job on some files to work around build server limitation.
+* GIT: Option `git.pushOptions` can now be set to add additional git options to the git push.
 * SVN: Option `svn.pinExternals` can now be set to pin the version of externals
 
 ### Bugfixes

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Below are some properties of the Release Plugin Convention that are specific to 
 		<td>master</td>
 		<td>Defines the branch which releases must be done off of. Eg. set to `release` to require releases are done on the `release` branch (or use a regular expression to allow releases from multiple branches, e.g. `/release|master/`). Set to '' to ignore.</td>
 	</tr>
+	<tr>
+		<td>Git</td>
+		<td>pushOptions</td>
+		<td>{empty}</td>
+		<td>Defines an array of options to add to the git adapter during a push.  This could be useful to have the vc hooks skipped during a release. Example `pushOptions = ["--no-verify"]`</td>
+	</tr>
 </table>
 
 To set any of these properties to false, add a "release" configuration to your project's ```build.gradle``` file. Eg. To ignore un-versioned files, you would add the following to your ```build.gradle``` file:

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -27,7 +27,8 @@ class GitAdapter extends BaseScmAdapter {
     class GitConfig {
         String requireBranch = 'master'
         def pushToRemote = 'origin' // needs to be def as can be boolean or string
-
+        def pushOptions = []
+        
         /** @deprecated Remove in version 3.0 */
         @Deprecated
         boolean pushToCurrentBranch = false
@@ -106,7 +107,7 @@ class GitAdapter extends BaseScmAdapter {
         def tagName = tagName()
         exec(['git', 'tag', '-a', tagName, '-m', message], errorMessage: "Duplicate tag [$tagName]", errorPatterns: ['already exists'])
         if (shouldPush()) {
-            exec(['git', 'push', '--porcelain', extension.git.pushToRemote, tagName], errorMessage: "Failed to push tag [$tagName] to remote", errorPatterns: ['[rejected]', 'error: ', 'fatal: '])
+            exec(['git', 'push', '--porcelain', extension.git.pushToRemote, tagName] + extension.git.pushOptions, errorMessage: "Failed to push tag [$tagName] to remote", errorPatterns: ['[rejected]', 'error: ', 'fatal: '])
         }
     }
 
@@ -126,7 +127,7 @@ class GitAdapter extends BaseScmAdapter {
             if (extension.git.pushToBranchPrefix) {
                 branch = "HEAD:${extension.git.pushToBranchPrefix}${branch}"
             }
-            exec(['git', 'push', '--porcelain', extension.git.pushToRemote, branch], errorMessage: 'Failed to push to remote', errorPatterns: ['[rejected]', 'error: ', 'fatal: '])
+            exec(['git', 'push', '--porcelain', extension.git.pushToRemote, branch] + extension.git.pushOptions, errorMessage: 'Failed to push to remote', errorPatterns: ['[rejected]', 'error: ', 'fatal: '])
         }
     }
 

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
@@ -84,6 +84,7 @@ class GitReleasePluginTests extends Specification {
         project.release {
             git {
                 requireBranch = 'myBranch'
+                pushOptions = ['--no-verify', '--verbose']
             }
         }
         then:


### PR DESCRIPTION
our build runs static analysis and tests during a push. this makes the tagging process terribly slow (10+ minutes). This will permit me to skip those checks by supplying pushOptions = ["--no-verify"]