### PR TITLE
Support repo setup for submodule/-projects

### DIFF
--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -292,7 +292,7 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
      */
     protected BaseScmAdapter findScmAdapter() {
         BaseScmAdapter adapter
-        File projectPath = project.rootProject.projectDir.canonicalFile
+        File projectPath = project.projectDir.canonicalFile
 
         extension.scmAdapters.find {
             assert BaseScmAdapter.isAssignableFrom(it)


### PR DESCRIPTION
Our project setup is done with google repo and it looks like this

main
 |
 |-- module
 |    |--.git
 |    |-- build.gradle
 |
 | -- module1
 |      |-- build.gradle
 |      | -- sub-module
 |             |--.git
 |             |-- build.gradle (Use release plugin here)
 |- build.gradle (Use release plugin here)

And I want to be able to release "module1:sub-module" and main. But they should use their respective git repositories. After some testing I found out that the code did not support this.
So this is a possible solution for git.
