### PR TITLE
Git remote branch override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 out
 
 /.nb-gradle/
+/bin/

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Below are some properties of the Release Plugin Convention that are specific to 
 	    <td>false</td>
 	    <td>Adds `-s` parameter to the tag command</td>
 	</tr>
+	<tr>
+	    <td>Git</td>
+	    <td>pushToBranch</td>
+	    <td>{empty}</td>
+	    <td>Defines the remote branch to push to.  Useful when running the release in a detached head.</td>
+	</tr>
 </table>
 
 To set any of these properties to false, add a "release" configuration to your project's ```build.gradle``` file. Eg. To ignore un-versioned files, you would add the following to your ```build.gradle``` file:

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Below are some properties of the Release Plugin Convention that are specific to 
 	    <td>Git</td>
 	    <td>pushToBranch</td>
 	    <td>{empty}</td>
-	    <td>Defines the remote branch to push to.  Useful when running the release in a detached head.</td>
+	    <td>Defines the remote branch to push to.  Useful when running the release with a detached head.</td>
 	</tr>
 </table>
 
@@ -216,6 +216,7 @@ release {
     git {
         requireBranch = 'master'
         pushToRemote = 'origin'
+        pushToBranch = ''
         pushToBranchPrefix = ''
         commitVersionFileOnly = false
         signTag = false

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -134,7 +134,7 @@ class GitAdapter extends BaseScmAdapter {
         if (shouldPush()) {
             def branch = gitCurrentBranch()
             if (extension.git.pushToBranch) {
-                branch = pushToBranch
+                branch = extension.git.pushToBranch
             }
             if (extension.git.pushToBranchPrefix) {
                 branch = "HEAD:${extension.git.pushToBranchPrefix}${branch}"

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -135,7 +135,8 @@ class GitAdapter extends BaseScmAdapter {
             def branch = gitCurrentBranch()
             if (extension.git.pushToBranch) {
                 branch = pushToBranch
-            } else if (extension.git.pushToBranchPrefix) {
+            }
+            if (extension.git.pushToBranchPrefix) {
                 branch = "HEAD:${extension.git.pushToBranchPrefix}${branch}"
             }
             exec(['git', 'push', '--porcelain', extension.git.pushToRemote, branch] + extension.git.pushOptions, directory: workingDirectory, errorMessage: 'Failed to push to remote', errorPatterns: ['[rejected]', 'error: ', 'fatal: '])

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -37,7 +37,8 @@ class GitAdapter extends BaseScmAdapter {
         boolean pushToCurrentBranch = false
         String pushToBranchPrefix
         boolean commitVersionFileOnly = false
-
+        String pushToBranch
+        
         void setProperty(String name, Object value) {
             if (name == 'pushToCurrentBranch') {
                 project.logger?.warn("You are setting the deprecated and unused option '${name}'. You can safely remove it. The deprecated option will be removed in 3.0")
@@ -132,7 +133,9 @@ class GitAdapter extends BaseScmAdapter {
 
         if (shouldPush()) {
             def branch = gitCurrentBranch()
-            if (extension.git.pushToBranchPrefix) {
+            if (extension.git.pushToBranch) {
+                branch = pushToBranch
+            } else if (extension.git.pushToBranchPrefix) {
                 branch = "HEAD:${extension.git.pushToBranchPrefix}${branch}"
             }
             exec(['git', 'push', '--porcelain', extension.git.pushToRemote, branch] + extension.git.pushOptions, directory: workingDirectory, errorMessage: 'Failed to push to remote', errorPatterns: ['[rejected]', 'error: ', 'fatal: '])


### PR DESCRIPTION
Allows to specify the remote branch to push to with git, this means the plugin can be used in Jenkins where branches are checked out with detached HEAD's.  Fixes #183.