### PR TITLE
Add option pushReleaseVersionBranch to push release commit on a specific branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+bin
 .gradle
 *.iml
 *.ipr

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ The `gradle release` task defines the following as the default release process:
 
 * The plugin checks for any un-committed files (Added, modified, removed, or un-versioned).
 * Checks for any incoming or outgoing changes.
-* Checkout to the release branch and merge from the working branch (optionally for GIT only, with `pushReleaseVersionBranch`)
+* Checkout to the release branch and merge from the working branch (optional, for GIT only, with `pushReleaseVersionBranch`)
 * Removes the SNAPSHOT flag on your project's version (If used)
 * Prompts you for the release version.
 * Checks if your project is using any SNAPSHOT dependencies
 * Will `build` your project.
 * Commits the project if SNAPSHOT was being used.
 * Creates a release tag with the current version.
-* Checkout to the working branch (optionally for GIT only, with `pushReleaseVersionBranch`)
+* Checkout to the working branch (optional, for GIT only, with `pushReleaseVersionBranch`)
 * Prompts you for the next version.
 * Commits the project with the new version.
 
@@ -108,7 +108,7 @@ Below are some properties of the Release Plugin Convention that can be used to m
 	<tr>
 		<td>pushReleaseVersionBranch</td>
 		<td>false</td>
-		<td>(GIT only) If setted to the name of a branch, the `release` task will commit the release on this branch, and the next version on the working branch.</td>
+		<td>(GIT only) If set to the name of a branch, the `release` task will commit the release on this branch, and the next version on the working branch.</td>
 	</tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ The `gradle release` task defines the following as the default release process:
 
 * The plugin checks for any un-committed files (Added, modified, removed, or un-versioned).
 * Checks for any incoming or outgoing changes.
+* Checkout to the release branch and merge from the working branch (optionally for GIT only, with `pushReleaseVersionBranch`)
 * Removes the SNAPSHOT flag on your project's version (If used)
 * Prompts you for the release version.
 * Checks if your project is using any SNAPSHOT dependencies
 * Will `build` your project.
 * Commits the project if SNAPSHOT was being used.
 * Creates a release tag with the current version.
+* Checkout to the working branch (optionally for GIT only, with `pushReleaseVersionBranch`)
 * Prompts you for the next version.
 * Commits the project with the new version.
 
@@ -102,6 +104,11 @@ Below are some properties of the Release Plugin Convention that can be used to m
 		<td>revertOnFail</td>
 		<td>true</td>
 		<td>When a failure occurs should the plugin revert it's changes to gradle.properties?</td>
+	</tr>
+	<tr>
+		<td>pushReleaseVersionBranch</td>
+		<td>false</td>
+		<td>(GIT only) If setted to the name of a branch, the `release` task will commit the release on this branch, and the next version on the working branch.</td>
 	</tr>
 </table>
 
@@ -200,6 +207,7 @@ release {
     versionPatterns = [
         /(\d+)([^\d]*$)/: { Matcher m, Project p -> m.replaceAll("${(m[0][1] as int) + 1}${m[0][2]}") }
     ]
+	pushReleaseVersionBranch = false
     scmAdapters = [
         net.researchgate.release.GitAdapter,
         net.researchgate.release.SvnAdapter,

--- a/src/main/groovy/net/researchgate/release/BaseScmAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/BaseScmAdapter.groovy
@@ -10,6 +10,7 @@
 
 package net.researchgate.release
 
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 
 abstract class BaseScmAdapter extends PluginHelper {
@@ -37,4 +38,12 @@ abstract class BaseScmAdapter extends PluginHelper {
     abstract void commit(String message)
 
     abstract void revert()
+
+    void checkoutMergeToReleaseBranch() {
+        throw new GradleException("Checkout and merge is supported only for GIT projects")
+    }
+
+    void checkoutMergeFromReleaseBranch() {
+        throw new GradleException("Checkout and merge is supported only for GIT projects")
+    }
 }

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -151,10 +151,6 @@ class GitAdapter extends BaseScmAdapter {
 
     @Override
     void revert() {
-        // Try to go back to the requireBranch (workingBranch is irrelevant here, a new GitAdapter instance has been created specifically during revert)
-        if (extension.git.requireBranch) {
-            exec(['git', 'checkout', extension.git.requireBranch], directory: workingDirectory, errorMessage: 'Error reverting changes made by the release plugin.')
-        }
         // Revert changes on gradle.properties
         exec(['git', 'checkout', findPropertiesFile().name], directory: workingDirectory, errorMessage: 'Error reverting changes made by the release plugin.')
     }

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -168,7 +168,7 @@ class GitAdapter extends BaseScmAdapter {
     private checkoutMerge(String fromBranch, String toBranch) {
         exec(['git', 'fetch'], directory: workingDirectory, errorPatterns: ['error: ', 'fatal: '])
         exec(['git', 'checkout', toBranch], directory: workingDirectory, errorPatterns: ['error: ', 'fatal: '])
-        exec(['git', 'merge', '--no-ff', '--no-commit', fromBranch], directory: workingDirectory, errorPatterns: ['error: ', 'fatal: '])
+        exec(['git', 'merge', '--no-ff', '--no-commit', '--strategy=recursive', '-Xtheirs', fromBranch], directory: workingDirectory, errorPatterns: ['error: ', 'fatal: '])
     }
 
     private boolean shouldPush() {

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -172,7 +172,7 @@ class GitAdapter extends BaseScmAdapter {
     private checkoutMerge(String fromBranch, String toBranch) {
         exec(['git', 'fetch'], directory: workingDirectory, errorPatterns: ['error: ', 'fatal: '])
         exec(['git', 'checkout', toBranch], directory: workingDirectory, errorPatterns: ['error: ', 'fatal: '])
-        exec(['git', 'merge', '--no-ff', '--no-commit', '--strategy=recursive', '-Xtheirs', fromBranch], directory: workingDirectory, errorPatterns: ['error: ', 'fatal: '])
+        exec(['git', 'merge', '--no-ff', '--no-commit', fromBranch], directory: workingDirectory, errorPatterns: ['error: ', 'fatal: ', 'CONFLICT'])
     }
 
     private boolean shouldPush() {

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -194,7 +194,11 @@ class GitAdapter extends BaseScmAdapter {
 
     private String gitCurrentBranch() {
         def matches = exec(['git', 'branch', '--no-color'], directory: workingDirectory).readLines().grep(~/\s*\*.*/)
-        matches[0].trim() - (~/^\*\s+/)
+		if (!matches.isEmpty()) {
+			matches[0].trim() - (~/^\*\s+/)
+		} else {
+			throw new GradleException('Error, this repository is empty.')
+		}
     }
 
     private Map<String, List<String>> gitStatus() {

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -24,8 +24,8 @@ class GitAdapter extends BaseScmAdapter {
     private static final String AHEAD = 'ahead'
     private static final String BEHIND = 'behind'
 
-    private final String workingBranch;
-    private final String releaseBranch;
+    private final String workingBranch
+    private final String releaseBranch
 
     private File workingDirectory
 

--- a/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
@@ -38,6 +38,8 @@ class ReleaseExtension {
 
     String newVersionCommitMessage = '[Gradle Release Plugin] - new version commit: '
 
+    def pushReleaseVersionBranch = false
+
     /**
      * as of 3.0 set this to "$version" by default
      */

--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -133,8 +133,8 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
         project.task('afterReleaseBuild', group: RELEASE_GROUP,
             description: 'Runs immediately after the build when doing a release') {}
 
-        project.afterEvaluate {
-            if (supportsMustRunAfter) {
+        if (supportsMustRunAfter) {
+            project.afterEvaluate {
                 def buildTasks = extension.buildTasks
                 if (!buildTasks.empty) {
                     project.tasks[buildTasks.first()].mustRunAfter(project.tasks.beforeReleaseBuild)

--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -141,12 +141,6 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
                     project.tasks.afterReleaseBuild.mustRunAfter(project.tasks[buildTasks.last()])
                 }
             }
-
-            if (extension.pushReleaseVersionBranch && !extension.failOnCommitNeeded) {
-                log.warn('/!\\Warning/!\\')
-                log.warn('It is strongly discouraged to set failOnCommitNeeded to false with pushReleaseVersionBranch is enabled.')
-                log.warn('Merging if an uncleaned working directory will lead to unexpected results.')
-            }
         }
 
         project.gradle.taskGraph.afterTask { Task task, TaskState state ->
@@ -181,10 +175,22 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
     }
 
     void checkoutAndMergeToReleaseBranch() {
+        if (extension.pushReleaseVersionBranch && !extension.failOnCommitNeeded) {
+            log.warn('/!\\Warning/!\\')
+            log.warn('It is strongly discouraged to set failOnCommitNeeded to false with pushReleaseVersionBranch is enabled.')
+            log.warn('Merging with an uncleaned working directory will lead to unexpected results.')
+        }
+
         scmAdapter.checkoutMergeToReleaseBranch()
     }
 
     void checkoutAndMergeFromReleaseBranch() {
+        if (extension.pushReleaseVersionBranch && !extension.failOnCommitNeeded) {
+            log.warn('/!\\Warning/!\\')
+            log.warn('It is strongly discouraged to set failOnCommitNeeded to false with pushReleaseVersionBranch is enabled.')
+            log.warn('Merging with an uncleaned working directory will lead to unexpected results.')
+        }
+
         scmAdapter.checkoutMergeFromReleaseBranch()
     }
 

--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -143,16 +143,9 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
             }
 
             if (extension.pushReleaseVersionBranch && !extension.failOnCommitNeeded) {
-                extension.failOnCommitNeeded = true
-                log.warn('Warning : Property release.failOnCommitNeeded enforced to be true when release.pushReleaseVersionBranch is set.')
-            }
-            if (extension.pushReleaseVersionBranch && !extension.failOnPublishNeeded) {
-                extension.failOnPublishNeeded = true
-                log.warn('Warning : Property release.failOnPublishNeeded enforced to be true when release.pushReleaseVersionBranch is set.')
-            }
-            if (extension.pushReleaseVersionBranch && !extension.failOnUpdateNeeded) {
-                extension.failOnUpdateNeeded = true
-                log.warn('Warning : Property release.failOnUpdateNeeded enforced to be true when release.pushReleaseVersionBranch is set.')
+                log.warn('/!\\Warning/!\\')
+                log.warn('It is strongly discouraged to set failOnCommitNeeded to false with pushReleaseVersionBranch is enabled.')
+                log.warn('Merging if an uncleaned working directory will lead to unexpected results.')
             }
         }
 

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
@@ -43,13 +43,14 @@ class GitReleasePluginTests extends Specification {
         this.executor.exec(['git', 'config', '--add', 'user.email', 'unit@test'], failOnStderr: true, directory: localRepo, env: [:])
 
         project = ProjectBuilder.builder().withName("GitReleasePluginTest").withProjectDir(localRepo).build()
-        project.version = "1.1"
-        project.apply plugin: ReleasePlugin
-        project.createScmAdapter.execute()
+		project.version = "1.1"
+		project.apply plugin: ReleasePlugin
 
         project.file("somename.txt").withWriter {it << "test"}
         this.executor.exec(['git', 'add', 'somename.txt'], failOnStderr: true, directory: localRepo, env: [:])
         this.executor.exec(['git', 'commit', "-m", "test", 'somename.txt'], failOnStderr: true, directory: localRepo, env: [:])
+		
+		project.createScmAdapter.execute()
 
         def props = project.file("gradle.properties")
         props.withWriter { it << "version=${project.version}" }


### PR DESCRIPTION
Following submitted issue #195, I would like to propose an implementation of the asked functionnality on this PR, available for now only on GIT repositories.

Namely, this option allows to push the release commit (and the associated tag) on a release branch, and the new snapshot commit to the working branch (typically master). Of course the release commit is also a full-merge commit of the working branch at the time of the `release` task launch. This option is compatible with CI systems who publish releases from the release branch and snapshots from the working branch.

This functionality is activated by setting the property `pushReleaseVersionBranch` to the name of the release branch. By default, this property is setted to false and deactivate the functionality.

Typical example :
<pre>
release {
	pushReleaseVersionBranch = 'release'
	git {
		requireBranch = 'master'
	}
}
</pre>

To achieve this goal, two tasks are added to the release process :
* task `checkoutMergeToReleaseBranch` will checkout working directory to the release branch, and merge from the main branch with conflict auto-resolving to the main branch. This task is executed after `checkUpdateNeeded` if `pushReleaseVersionBranch != false`.
* task `checkoutMergeFromReleaseBranch` will checkout working tree to the main branch, and merge from the release branch with conflict auto-resolving to the release branch (technically not needed, but I like the symetry). This task is executed after `createReleaseTag` if `pushReleaseVersionBranch != false`.

I made further assumptions for this implementation :
* although the functionality is available to GIT only, and would throw a GradleException on other SCM providers, it could be extended to any SCM supporting branches. That's why I propose to apply `pushReleaseVersionBranch` at the `ReleaseExtension` level, and not the `GitConfig` level.
* in case of failure when the working directory is on release branch (typically on snapshot dependency check), the modified `revert` function will checkout on the working branch, if requireBranch has not been set to `false`. Otherwise, there is no way currently to know which was the working branch during error handling.
* following the previous assumption, I did not try to move the order execution of `checkSnapshotDependencies` which (for me) should be done juste after `checkUpdateNeeded` (and would avoid potential failures when the working directory is on the release branch). Indeed, I was not sure of the implications. However if you think it is not a problem, it would be better to make this modification.

This PR has been tested with and without `pushReleaseVersionBranch` set to a release branch, and expected behaviour is matched :
* if `false`, the two commit (release + next snapshot) are done on the working branch,
* if `'release'`, release commit is done on the release branch, next snapshot commit is done on the working branch.

I am available for any further discussions to improve this PR and integrate it.

Regards,
Adrien Ferrand