### PR TITLE
Fixed checkSnapshotDependencies task to check the buildscript dependencies.

### DIFF
--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -167,6 +167,9 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
             project.configurations.each { cfg ->
                 snapshotDependencies += cfg.dependencies?.matching(matcher)?.collect(collector)
             }
+            project.buildscript.configurations.each { cfg ->
+                snapshotDependencies += cfg.dependencies?.matching(matcher)?.collect(collector)
+            }
             if (snapshotDependencies.size() > 0) {
                 message += "\n\t${project.name}: ${snapshotDependencies}"
             }


### PR DESCRIPTION
This Pull Request fixes #230 by adding a check to the aforementioned task to check the buildscript dependencies too. Tests for the task have been updated too.