### PR TITLE
#247: Allow to ignore some snapshot dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Below are some properties of the Release Plugin Convention that can be used to m
 	<tr>
 		<td>failOnSnapshotDependencies</td>
 		<td>true</td>
-		<td>Fail when the project has dependencies on SNAPSHOT versions</td>
+		<td>Fail when the project has dependencies on SNAPSHOT versions unless those SNAPSHOT dependencies have been defined as 'ignoredSnapshotDependencies'</td>
 	</tr>
 	<tr>
 		<td>failOnUnversionedFiles</td>
@@ -197,6 +197,7 @@ release {
     versionPropertyFile = 'gradle.properties'
     versionProperties = []
     buildTasks = ['build']
+    ignoredSnapshotDependencies = []
     versionPatterns = [
         /(\d+)([^\d]*$)/: { Matcher m, Project p -> m.replaceAll("${(m[0][1] as int) + 1}${m[0][2]}") }
     ]

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Below are some properties of the Release Plugin Convention that can be used to m
 	<tr>
 		<td>failOnSnapshotDependencies</td>
 		<td>true</td>
-		<td>Fail when the project has dependencies on SNAPSHOT versions unless those SNAPSHOT dependencies have been defined as 'ignoredSnapshotDependencies'</td>
+		<td>Fail when the project has dependencies on SNAPSHOT versions unless those SNAPSHOT dependencies have been defined as <i>'ignoredSnapshotDependencies'</i> using the syntax '$group:$name'</td>
 	</tr>
 	<tr>
 		<td>failOnUnversionedFiles</td>

--- a/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
@@ -48,6 +48,8 @@ class ReleaseExtension {
     List versionProperties = []
 
     List buildTasks = ['build']
+	
+    List ignoredSnapshotDependencies = []
 
     Map<String, Closure<String>> versionPatterns = [
         // Increments last number: "2.5-SNAPSHOT" => "2.6-SNAPSHOT"

--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -157,7 +157,7 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
     }
 
     void checkSnapshotDependencies() {
-        def matcher = { Dependency d -> d.version?.contains('SNAPSHOT') && !extension.ignoredSnapshotDependencies.contains(d.name) }
+        def matcher = { Dependency d -> d.version?.contains('SNAPSHOT') && !extension.ignoredSnapshotDependencies.contains("${d.group ?: ''}:${d.name}".toString()) }
         def collector = { Dependency d -> "${d.group ?: ''}:${d.name}:${d.version ?: ''}" }
 
         def message = ""

--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -157,7 +157,7 @@ class ReleasePlugin extends PluginHelper implements Plugin<Project> {
     }
 
     void checkSnapshotDependencies() {
-        def matcher = { Dependency d -> d.version?.contains('SNAPSHOT') }
+        def matcher = { Dependency d -> d.version?.contains('SNAPSHOT') && !extension.ignoredSnapshotDependencies.contains(d.name) }
         def collector = { Dependency d -> "${d.group ?: ''}:${d.name}:${d.version ?: ''}" }
 
         def message = ""

--- a/src/test/groovy/net/researchgate/release/ReleasePluginCheckSnapshotDependenciesTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginCheckSnapshotDependenciesTests.groovy
@@ -114,7 +114,7 @@ public class ReleasePluginCheckSnapshotDependenciesTests extends Specification {
         given:
         project.configurations { custom }
         project.dependencies { custom 'my:my:1.1.1-SNAPSHOT' }
-        project.release.ignoredSnapshotDependencies = ['my']
+        project.release.ignoredSnapshotDependencies = ['my:my']
         when:
         project.checkSnapshotDependencies.execute()
         then:

--- a/src/test/groovy/net/researchgate/release/ReleasePluginCheckSnapshotDependenciesTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginCheckSnapshotDependenciesTests.groovy
@@ -109,4 +109,15 @@ public class ReleasePluginCheckSnapshotDependenciesTests extends Specification {
         GradleException ex = thrown()
         ex.cause.message.contains '[my1:my1:1.1.1-SNAPSHOT, my2:my2:1.1.1-SNAPSHOT]'
     }
+
+    def 'when a SNAPSHOT dep is ignored then no exception'() {
+        given:
+        project.configurations { custom }
+        project.dependencies { custom 'my:my:1.1.1-SNAPSHOT' }
+        project.release.ignoredSnapshotDependencies = ['my']
+        when:
+        project.checkSnapshotDependencies.execute()
+        then:
+        notThrown GradleException
+    }	
 }


### PR DESCRIPTION
Fix for #247 

* Add a new list in which we can provide the name of artifact to ignore
* Add a test in the matcher to check whether the dependency should be ignored