### PR TITLE
#260: Allow to change the format of the name and the version while building the tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ Below are some properties of the Release Plugin Convention that can be used to c
 		<td>The string template which is used to generate the tag name. Possible variables are $version and $name. Example: '$name-$version' will result in "myproject-1.1.0". (Always ensure to use single-quotes, otherwise `$` is interpreted already in your build script)</td>
 	</tr>
 	<tr>
+		<td>tagProjectNameFormatter</td>
+		<td></td>
+		<td>The formatter to use to change the format of the project name before generating the tag name. The expected value is a closure that returns a String with the project name as argument, for example {name -> name.toLowerCase()}. Only used when tagTemplate is set.</td>
+	</tr>
+	<tr>
+		<td>tagProjectVersionFormatter</td>
+		<td></td>
+		<td>The formatter to use to change the format of the project version before generating the tag name. The expected value is a closure that returns a String with the project version as argument, for example {version -> version.replace('.', '_')}. Only used when tagTemplate is set.</td>
+	</tr>
+	<tr>
 		<td>preCommitText</td>
 		<td></td>
 		<td>This will be prepended to all commits done by the plugin. A good place for code review, or ticket numbers</td>
@@ -194,6 +204,8 @@ release {
     tagCommitMessage = '[Gradle Release Plugin] - creating tag: '
     newVersionCommitMessage = '[Gradle Release Plugin] - new version commit: '
     tagTemplate = '${version}'
+    tagProjectNameFormatter = null
+    tagProjectVersionFormatter = null
     versionPropertyFile = 'gradle.properties'
     versionProperties = []
     buildTasks = ['build']

--- a/src/main/groovy/net/researchgate/release/PluginHelper.groovy
+++ b/src/main/groovy/net/researchgate/release/PluginHelper.groovy
@@ -122,8 +122,8 @@ class PluginHelper {
         if (extension.tagTemplate) {
             def engine = new SimpleTemplateEngine()
             def binding = [
-                "version": project.version,
-                "name"   : project.name
+                "version": extension.tagProjectVersionFormatter?.call(project.version) ?: project.version,
+                "name"   : extension.tagProjectNameFormatter?.call(project.name) ?: project.name
             ]
             tagName = engine.createTemplate(extension.tagTemplate).make(binding).toString()
         } else {

--- a/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
@@ -42,6 +42,14 @@ class ReleaseExtension {
      * as of 3.0 set this to "$version" by default
      */
     String tagTemplate
+    /**
+     * Allows to format the project version used to build the tag name
+     */
+    Closure<String> tagProjectVersionFormatter
+    /**
+     * Allows to format the project name used to build the tag name
+     */
+    Closure<String> tagProjectNameFormatter
 
     String versionPropertyFile = 'gradle.properties'
 

--- a/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
+++ b/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
@@ -80,4 +80,15 @@ public class PluginHelperTagNameTests extends Specification {
         expect:
         helper.tagName() == 'PREF-ReleasePluginTest-1.1'
     }
+
+    def 'when tagTemplate not blank and project name and project version formatters have been set then they are used to build the tag name'() {
+        given:
+        project.release {
+            tagTemplate = 'PREF-$name-$version'
+			tagProjectVersionFormatter = {version -> version.replace('.', '_')}
+			tagProjectNameFormatter = {name -> name.toLowerCase()}
+        }
+        expect:
+        helper.tagName() == 'PREF-releaseplugintest-1_1'
+    }
 }


### PR DESCRIPTION
Fix for #260 

- Adds the parameter `tagProjectNameFormatter` to format the project name
- Adds the parameter `tagProjectVersionFormatter` to format the project version