### PR TITLE
chore: extend tests to cover various semantic versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 language: groovy
 jdk:
   - oraclejdk8
-  - oraclejdk9
   - openjdk8
 notifications:
     webhooks: https://www.travisbuddy.com/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ cache:
 language: groovy
 jdk:
   - oraclejdk8
+  - oraclejdk9
+  - openjdk8
 notifications:
     webhooks: https://www.travisbuddy.com/

--- a/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
@@ -141,6 +141,50 @@ class ReleasePluginTests extends Specification {
         project.version == '1.5-dev'
     }
 
+    def 'version should be unsnapshot to release version'() {
+        given:
+            def testVersionPropertyFile = project.file('gradle.properties')
+            testVersionPropertyFile.withWriter { w ->
+                w.writeLine 'version=' + currentVersion
+            }
+        when:
+            project.unSnapshotVersion.execute()
+        then:
+            project.version == expectedNewVersion
+        where:
+            currentVersion              | expectedNewVersion
+            "1.4-SNAPSHOT"              | "1.4"
+            "1.4-SNAPSHOT+meta"         | "1.4+meta"
+            "1.4-SNAPSHOT+3.2.1"        | "1.4+3.2.1"
+            "1.4-SNAPSHOT+rel-201908"   | "1.4+rel-201908"
+    }
+
+    def 'version should be updated to new version'() {
+        given:
+            def testVersionPropertyFile = project.file('gradle.properties')
+            testVersionPropertyFile.withWriter { w ->
+                w.writeLine 'version=' + currentVersion
+            }
+            project.release {
+                useAutomaticVersion = true
+            }
+        when:
+            project.updateVersion.execute()
+        then:
+            project.version == expectedNewVersion
+        where:
+            currentVersion              | expectedNewVersion
+            "1.4-SNAPSHOT"              | "1.5-SNAPSHOT"
+            "1.4-SNAPSHOT+meta"         | "1.5-SNAPSHOT+meta"
+            "1.4-SNAPSHOT+3.2.1"        | "1.5-SNAPSHOT+3.2.1"
+            "1.4-SNAPSHOT+rel-201908"   | "1.5-SNAPSHOT+rel-201908"
+            "1.4+meta"                  | "1.5+meta"
+            "1.4"                       | "1.5"
+            "1.4.2"                     | "1.4.3"
+            "1.4.2+4.5.6"               | "1.4.3+4.5.6"
+            "1.4+rel-201908"            | "1.5+rel-201908"
+    }
+
     def 'subproject tasks are named with qualified paths'() {
         given:
         Project sub = ProjectBuilder.builder().withName('sub').withParent(project).withProjectDir(testDir).build()


### PR DESCRIPTION
This PR is extending the ReleasePluginTests to validate the methods `unSnapshotVersion` and `updateVersion` against various semantic versions.

Right now 4 tests are failing since they do not handle properly [semver metadata](https://semver.org/#spec-item-10). Most likely due to the default `versionPattern`.