### PR TITLE
Use HTTPS for JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
     repositories {
-        jcenter()
+        jcenter {
+            url "https://jcenter.bintray.com"
+        }
     }
     dependencies {
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.3.0'


### PR DESCRIPTION
JFrog JCenter does not allow HTTP anymore; the rather old gradle version probably defaults to an HTTP URL. This change might gradle lead to use the HTTPS URL.