### PR TITLE
Update to Gradle 4.10

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 04 07:48:37 CET 2015
+#Sun Apr 05 21:14:59 BST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
1.12 is incompatible with later versions (detected by importing into IntelliJ) ; it is 8 years old. 4.10 is 2 years old - it is fairly common along with 5.x in general usage.