### PR TITLE
Fix to allow releases on any Git branch

### DIFF
--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -84,7 +84,7 @@ class GitAdapter extends BaseScmAdapter {
         } else {
             releaseBranch = workingBranch
         }
-        if (extension.git.requireBranch.isPresent()) {
+        if (extension.git.requireBranch.isPresent() && extension.git.requireBranch.get()) {
             if (!(workingBranch ==~ extension.git.requireBranch.get())) {
                 throw new GradleException("Current Git branch is \"$workingBranch\" and not \"${ extension.git.requireBranch.get() }\".")
             }


### PR DESCRIPTION
requireBranch is always present due to the convention on the property. Even when overriding to empty string or null it is still considered present.