### PR TITLE
Proposal to add `commitOptions` to git config -- Update GitAdapter.groovy

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ Below are some properties of the Release Plugin Convention that are specific to 
 	</tr>
 	<tr>
 		<td>Git</td>
+		<td>commitOptions</td>
+		<td>{empty}</td>
+		<td>Defines an array of options to add to the git adapter during a commit.  Example `commitOptions = ["-s"]`</td>
+	</tr>
+	<tr>
+		<td>Git</td>
 		<td>pushOptions</td>
 		<td>{empty}</td>
 		<td>Defines an array of options to add to the git adapter during a push.  This could be useful to have the vc hooks skipped during a release. Example `pushOptions = ["--no-verify"]`</td>

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -40,6 +40,9 @@ class GitAdapter extends BaseScmAdapter {
         final Property<String> requireBranch
         @Optional
         @Input
+        ListProperty<String> commitOptions
+        @Optional
+        @Input
         final Property<Object> pushToRemote
         @Optional
         @Input
@@ -54,6 +57,7 @@ class GitAdapter extends BaseScmAdapter {
 
         GitConfig(Project project) {
             requireBranch = project.objects.property(String.class).convention('main')
+            commitOptions = project.objects.listProperty(String.class).convention([])
             pushToRemote = project.objects.property(Object.class).convention('origin')
             pushOptions = project.objects.listProperty(String.class).convention([])
             signTag = project.objects.property(Boolean.class).convention(false)
@@ -142,6 +146,7 @@ class GitAdapter extends BaseScmAdapter {
         } else {
             command << '-a'
         }
+        command += extension.git.commitOptions.get()
 
         exec(command, directory: workingDirectory, errorPatterns: ['error: ', 'fatal: '])
 


### PR DESCRIPTION
Proposal for adding git commit options.

This means a user can do something like ["-s"] to satisfy DCO bots: https://github.com/apps/dco