### PR TITLE
Fix GitReleasePluginTests when global .gitconfig contains custom pretty format settings

### DIFF
--- a/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
@@ -126,7 +126,7 @@ class GitReleasePluginTests extends Specification {
             }
         }
         (project.tasks.commitNewVersion as CommitNewVersion).commitNewVersion()
-        String newestCommit = executor.exec(['git', 'show', 'myBranch', '-s'], failOnStderr: false, directory: remoteRepo, env: [:])
+        String newestCommit = executor.exec(['git', 'show', 'myBranch', '-s', '--pretty=medium'], failOnStderr: false, directory: remoteRepo, env: [:])
         executor.exec(['git', 'checkout', 'myBranch'], failOnStderr: false, directory: remoteRepo, env: [:])
         executor.exec(['git', 'reset', '--hard', 'HEAD'], failOnStderr: false, directory: remoteRepo, env: [:])
         then:


### PR DESCRIPTION
Test case "commitOptions are passed through to git command" would fail on my machine due to custom pretty format settings:

~/.gitconfig:
```
[format]
	pretty = %Cgreen%ci:%C(yellow)%d%Creset|%G?|%s (%Cred%h%Creset by %C(bold blue)%an%Creset) %ae [%GS]
```

This resulted in the following test failure:

```
Condition not satisfied:

newestCommit.contains("Signed-off-by: Unit Test <unit@test>")
|            |
|            false
2023-03-26 15:23:54 +0200: (myBranch)|N|[Gradle Release Plugin] - new version commit:  '1.1'. (40b3a21 by Unit Test) unit@test []

	at net.researchgate.release.GitReleasePluginTests.commitOptions are passed through to git command(GitReleasePluginTests.groovy:133)
```

This is a simple fix which tells the test to request the information it needs ("pretty=medium") rather than expecting the defaults to be right. 