### PR TITLE
Add support for a "manual" SCM Adapter

### DIFF
--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -10,7 +10,6 @@
 
 package net.researchgate.release
 
-import com.sun.org.apache.xpath.internal.operations.Bool
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty

--- a/src/main/groovy/net/researchgate/release/ManualAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/ManualAdapter.groovy
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the gradle-release plugin.
+ *
+ * (c) Eric Berry
+ * (c) ResearchGate GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+package net.researchgate.release
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+import java.util.regex.Matcher
+
+/**
+ * This ManualAdapter does not interact with any SCM. Instead, it informs the user of manual steps to be executed.
+ */
+class ManualAdapter extends BaseScmAdapter {
+
+    private File workingDirectory
+
+    ManualAdapter(Project project, Map<String, Object> attributes) {
+        super(project, attributes)
+    }
+
+    // The ManualAdapter is always supported.
+    @Override
+    boolean isSupported(File directory) {
+        true
+    }
+
+    @Override
+    void init() {
+    }
+
+    @Override
+    void checkCommitNeeded() {
+        if (!promptYesOrNo('Have all modified files been committed?', true)) {
+            warnOrThrow(true, 'You have uncommitted changes.')
+        }
+    }
+
+    @Override
+    void checkUpdateNeeded() {
+        if (!promptYesOrNo('Have all remote modifications been pulled, and local changes pushed?', true)) {
+            warnOrThrow(true, 'You have unmerged remote changes.')
+        }
+    }
+
+    @Override
+    void createReleaseTag(String message) {
+        def tagName = tagName()
+        if (!promptYesOrNo("You should now tag the release. Suggested name: [$tagName]. Did you create the tag?", true)) {
+            warnOrThrow(true, 'You did not create a release tag.')
+        }
+    }
+
+    @Override
+    void commit(String message) {
+        if (!promptYesOrNo("You should now commit the changes. Suggested commit message: [$message]. Did you commit the changes?", true)) {
+            warnOrThrow(true, 'You did not commit the changes.')
+        }
+    }
+
+    @Override
+    void add(File file) {
+    }
+
+    @Override
+    void revert() {
+        def pptsFile = findPropertiesFile().name
+        println "You should revert the changes to [$pptsFile]"
+    }
+}

--- a/src/main/groovy/net/researchgate/release/PluginHelper.groovy
+++ b/src/main/groovy/net/researchgate/release/PluginHelper.groovy
@@ -183,7 +183,7 @@ class PluginHelper {
         System.in.newReader().readLine() ?: defaultValue
     }
 
-    private static boolean promptYesOrNo(String message, boolean defaultValue = false) {
+    protected static boolean promptYesOrNo(String message, boolean defaultValue = false) {
         String defaultStr = defaultValue ? 'Y' : 'n'
         String consoleVal = readLine("${message} (Y|n)", defaultStr)
         if (consoleVal) {

--- a/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
@@ -95,7 +95,8 @@ class ReleaseExtension {
         GitAdapter,
         SvnAdapter,
         HgAdapter,
-        BzrAdapter
+        BzrAdapter,
+        ManualAdapter
     ]
 
     @Internal

--- a/src/test/groovy/net/researchgate/release/ManualAdapterTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ManualAdapterTests.groovy
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the gradle-release plugin.
+ *
+ * (c) Eric Berry
+ * (c) ResearchGate GmbH
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+package net.researchgate.release
+
+import net.researchgate.release.cli.Executor
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class ManualAdapterTests extends Specification {
+    Project project
+    ManualAdapter manualAdapter
+    ByteArrayOutputStream stdout
+
+    File testDir = new File("build/tmp/test/${getClass().simpleName}")
+
+    def setup() {
+        project = project = ProjectBuilder.builder().withName("ManualAdapterTests").withProjectDir(testDir).build()
+        project.apply plugin: ReleasePlugin
+        project.version = '1.0.0'
+
+        def props = project.file("gradle.properties")
+        props.withWriter {it << "version=${project.version}"}
+
+        manualAdapter = new ManualAdapter(project, [:])
+        manualAdapter.executor = Mock(Executor)
+        // Reassign stdout so we can perform assertions on it
+        stdout = new ByteArrayOutputStream()
+        System.out = new PrintStream(stdout)
+    }
+
+    def "manual adapter is always supported"() {
+        when:
+        def supported = manualAdapter.isSupported(null)
+
+        then:
+        supported == true
+    }
+
+    def "manual adapter checkCommitNeeded - no commit needed"() {
+        when:
+        manualAdapter.checkCommitNeeded()
+
+        then:
+        stdout.toString().contains('Have all modified files been committed?')
+    }
+
+    def "manual adapter checkUpdateNeeded - no update needed"() {
+        when:
+        manualAdapter.checkUpdateNeeded()
+
+        then:
+        stdout.toString().contains('Have all remote modifications been pulled')
+    }
+
+    def "manual adapter commit - no automatic commits"() {
+        when:
+        manualAdapter.commit('test message')
+
+        then:
+        stdout.toString().contains('You should now commit the changes. Suggested commit message: [test message]. Did you commit the changes?')
+    }
+
+    def "manual adapter revert"() {
+        when:
+        manualAdapter.revert()
+
+        then:
+        stdout.toString().contains('You should revert the changes to [gradle.properties]')
+    }
+}


### PR DESCRIPTION
The main use case is being able to release using unsupported SCMs. But this is also a useful workaround for complex git setups: the plugin uses "exec" to execute `git`, which ignores shell aliases, which breaks some git setups.

When using the following configuration, gradle-release will ask a few extra questions during the release process, and will give the user the chance to commit and tag things by hand.

```
release {
	scmAdapters = [
		net.researchgate.release.ManualAdapter
	]
}
```