### PR TITLE
Do not add an excessive space in the pre tag commit message if no pre commit text is set

### DIFF
--- a/src/main/groovy/net/researchgate/release/tasks/PreTagCommit.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/PreTagCommit.groovy
@@ -22,7 +22,7 @@ class PreTagCommit extends BaseReleaseTask {
         if (projectAttributes.usesSnapshot || projectAttributes.versionModified || projectAttributes.propertiesFileCreated) {
             // should only be committed if the project was using a snapshot version.
             String message = extension.preTagCommitMessage.get() + " '${tagName()}'."
-            if (extension.preCommitText) {
+            if (extension.preCommitText.get()) {
                 message = "${extension.preCommitText.get()} ${message}"
             }
             if (projectAttributes.propertiesFileCreated) {


### PR DESCRIPTION
fixes #361