### PR TITLE
Make test cross-OS safe

### DIFF
--- a/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
@@ -33,7 +33,7 @@ class ReleasePluginTests extends Specification {
         project = ProjectBuilder.builder().withName('ReleasePluginTest').withProjectDir(testDir).build()
         def testVersionPropertyFile = project.file('version.properties')
         testVersionPropertyFile.withWriter { w ->
-            w.writeLine 'version=1.2'
+            w.write 'version=1.2\n'
         }
         project.plugins.apply(BasePlugin.class)
         ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)


### PR DESCRIPTION
Without this, the test fails on Windows due to different line end sequence.