### PR TITLE
Modify comments about `requireBranch` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ configure<ReleaseExtension> {
     ignoredSnapshotDependencies.set(listOf("net.researchgate:gradle-release"))
     with(git) {
         requireBranch.set("master")
-        // to disable branch verification: requireBranch.set(null as String?)
+        // to disable branch verification, set empty string: requireBranch.set("")
     }
 }
 ```


### PR DESCRIPTION
As stated in the README and unit test, to skip verification for requireBranch, we have to  pass an empty string.
- [README](https://github.com/researchgate/gradle-release/blob/9280d4ad1220d72384326e551a057f8afe1dbddb/README.md?plain=1#L160-L164)
- [test](https://github.com/researchgate/gradle-release/blob/9280d4ad1220d72384326e551a057f8afe1dbddb/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy#L136-L149)

When null is provided, the default value is used. This change modifies the comment to provide correct usage.





