### PR TITLE
fix: register operation completion listener with BuildServiceRegistry

### DIFF
--- a/src/main/groovy/net/researchgate/release/BzrAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/BzrAdapter.groovy
@@ -11,15 +11,14 @@
 package net.researchgate.release
 
 import org.gradle.api.GradleException
-import org.gradle.api.Project
 
-class BzrAdapter extends BaseScmAdapter {
+class BzrAdapter extends BaseScmAdapter<Cacheable> {
 
     private static final String ERROR = 'ERROR'
     private static final String DELIM = '\n  * '
 
-    BzrAdapter(Project project, Map<String, Object> attributes) {
-        super(project, attributes)
+    BzrAdapter(PluginHelper pluginHelper) {
+        super(pluginHelper, new Cacheable(pluginHelper.toCacheable()))
     }
 
     @Override
@@ -120,8 +119,15 @@ class BzrAdapter extends BaseScmAdapter {
         exec(['bzr', 'add', file.path], errorMessage: "Error adding file ${file.name}", errorPatterns: [ERROR])
     }
 
-    @Override
-    void revert() {
-        exec(['bzr', 'revert', findPropertiesFile().name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
+    static class Cacheable extends BaseScmAdapter.Cacheable {
+
+        Cacheable(CacheablePluginHelper cacheablePluginHelper) {
+            super(cacheablePluginHelper)
+        }
+
+        @Override
+        void revert() {
+            exec(['bzr', 'revert', propertiesFile.name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
+        }
     }
 }

--- a/src/main/groovy/net/researchgate/release/CacheablePluginHelper.groovy
+++ b/src/main/groovy/net/researchgate/release/CacheablePluginHelper.groovy
@@ -1,0 +1,46 @@
+package net.researchgate.release
+
+import net.researchgate.release.cli.Executor
+import org.gradle.api.Project
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Serializable to be cached by Gradle.
+ *
+ * <p>Mark any fields that cannot be serialized as {@code transient} and handle {@code null} values (when deserialized).
+ */
+class CacheablePluginHelper implements Serializable {
+
+    private final File projectRootDir
+    private final File propertiesFile
+
+    private final transient Logger log
+
+    private transient Executor executor
+
+    CacheablePluginHelper(Project project, ReleaseExtension extension) {
+        projectRootDir = project.rootDir
+        propertiesFile = project.file(extension.versionPropertyFile)
+        log = project.logger
+    }
+
+    File getPropertiesFile() {
+        propertiesFile
+    }
+
+    String exec(
+            Map options = [:],
+            List<String> commands
+    ) {
+        initExecutor()
+        options['directory'] = options['directory'] ?: projectRootDir
+        executor.exec(options, commands)
+    }
+
+    private void initExecutor() {
+        if (!executor) {
+            executor = new Executor(log ?: LoggerFactory.getLogger(this.class))
+        }
+    }
+}

--- a/src/main/groovy/net/researchgate/release/GitAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/GitAdapter.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.tasks.Optional
 
 import java.util.regex.Matcher
 
-class GitAdapter extends BaseScmAdapter {
+class GitAdapter extends BaseScmAdapter<Cacheable> {
 
     private static final String LINE = '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 
@@ -29,10 +29,10 @@ class GitAdapter extends BaseScmAdapter {
     private static final String AHEAD = 'ahead'
     private static final String BEHIND = 'behind'
 
+    private final String versionPropertyFilePath
+
     private String workingBranch
     private String releaseBranch
-
-    private File workingDirectory
 
     static class GitConfig {
 
@@ -66,8 +66,13 @@ class GitAdapter extends BaseScmAdapter {
         }
     }
 
-    GitAdapter(Project project, Map<String, Object> attributes) {
-        super(project, attributes)
+    GitAdapter(PluginHelper pluginHelper) {
+        super(pluginHelper, new Cacheable(pluginHelper.toCacheable()))
+        versionPropertyFilePath = propertiesFile.path
+    }
+
+    File getWorkingDirectory() {
+        cacheableScmAdapter.workingDirectory
     }
 
     @Override
@@ -76,7 +81,7 @@ class GitAdapter extends BaseScmAdapter {
             return directory.parentFile? isSupported(directory.parentFile) : false
         }
 
-        workingDirectory = directory
+        cacheableScmAdapter.workingDirectory = directory
         true
     }
 
@@ -142,7 +147,7 @@ class GitAdapter extends BaseScmAdapter {
     void commit(String message) {
         List<String> command = ['git', 'commit', '-m', message]
         if (extension.git.commitVersionFileOnly.get()) {
-            command << project.file(extension.versionPropertyFile.get())
+            command << versionPropertyFilePath
         } else {
             command << '-a'
         }
@@ -162,12 +167,6 @@ class GitAdapter extends BaseScmAdapter {
     @Override
     void add(File file) {
         exec(['git', 'add', file.path], directory: workingDirectory, errorMessage: "Error adding file ${file.name}", errorPatterns: ['error: ', 'fatal: '])
-    }
-
-    @Override
-    void revert() {
-        // Revert changes on gradle.properties
-        exec(['git', 'checkout', findPropertiesFile().name], directory: workingDirectory, errorMessage: 'Error reverting changes made by the release plugin.')
     }
 
     @Override
@@ -236,5 +235,20 @@ class GitAdapter extends BaseScmAdapter {
             remoteStatus[BEHIND] = behindMatcher[0][1]
         }
         remoteStatus
+    }
+
+    static class Cacheable extends BaseScmAdapter.Cacheable {
+
+        protected File workingDirectory
+
+        Cacheable(CacheablePluginHelper cacheablePluginHelper) {
+            super(cacheablePluginHelper)
+        }
+
+        @Override
+        void revert() {
+            // Revert changes on gradle.properties
+            exec(['git', 'checkout', propertiesFile.name], directory: workingDirectory, errorMessage: 'Error reverting changes made by the release plugin.')
+        }
     }
 }

--- a/src/main/groovy/net/researchgate/release/HgAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/HgAdapter.groovy
@@ -10,14 +10,12 @@
 
 package net.researchgate.release
 
-import org.gradle.api.Project
-
-class HgAdapter extends BaseScmAdapter {
+class HgAdapter extends BaseScmAdapter<Cacheable> {
 
     private static final String ERROR = 'abort:'
 
-    HgAdapter(Project project, Map<String, Object> attributes) {
-        super(project, attributes)
+    HgAdapter(PluginHelper pluginHelper) {
+        super(pluginHelper, new Cacheable(pluginHelper.toCacheable()))
     }
 
     @Override
@@ -90,12 +88,19 @@ class HgAdapter extends BaseScmAdapter {
         exec(['hg', 'add', file.path], errorMessage: "Error adding file ${file.name}", errorPatterns: [ERROR])
     }
 
-    @Override
-    void revert() {
-        exec(['hg', 'revert', findPropertiesFile().name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
-    }
-
     private String hgCurrentBranch() {
         exec(['hg', 'branch']).readLines()[0]
+    }
+
+    static class Cacheable extends BaseScmAdapter.Cacheable {
+
+        Cacheable(CacheablePluginHelper cacheablePluginHelper) {
+            super(cacheablePluginHelper)
+        }
+
+        @Override
+        void revert() {
+            exec(['hg', 'revert', propertiesFile.name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
+        }
     }
 }

--- a/src/main/groovy/net/researchgate/release/SvnAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/SvnAdapter.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.tasks.Optional
 import java.util.regex.Matcher
 import org.gradle.api.GradleException
 
-class SvnAdapter extends BaseScmAdapter {
+class SvnAdapter extends BaseScmAdapter<Cacheable> {
 
     private static final String ERROR = 'Commit failed'
 
@@ -31,8 +31,8 @@ class SvnAdapter extends BaseScmAdapter {
 
     private static final def environment = [LANG: 'C', LC_MESSAGES: 'C', LC_ALL: ''];
 
-    SvnAdapter(Project project, Map<String, Object> attributes) {
-        super(project, attributes)
+    SvnAdapter(PluginHelper pluginHelper) {
+        super(pluginHelper, new Cacheable(pluginHelper.toCacheable()))
     }
 
     static class SvnConfig {
@@ -171,11 +171,6 @@ class SvnAdapter extends BaseScmAdapter {
         svnExec(['add', file.path], errorMessage: "Error adding file ${file.name}", errorPatterns: ['warning:'])
     }
 
-    @Override
-    void revert() {
-        svnExec(['revert', findPropertiesFile().name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
-    }
-
     /**
      * Adds the executable and optional also username/password
      *
@@ -218,6 +213,18 @@ class SvnAdapter extends BaseScmAdapter {
         }
         if (!attributes.svnUrl || !attributes.initialSvnRev) {
             throw new GradleException('Could not determine root SVN url or revision.')
+        }
+    }
+
+    static class Cacheable extends BaseScmAdapter.Cacheable {
+
+        Cacheable(CacheablePluginHelper cacheablePluginHelper) {
+            super(cacheablePluginHelper)
+        }
+
+        @Override
+        void revert() {
+            svnExec(['revert', propertiesFile.name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
         }
     }
 }

--- a/src/main/groovy/net/researchgate/release/tasks/BaseReleaseTask.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/BaseReleaseTask.groovy
@@ -2,6 +2,7 @@ package net.researchgate.release.tasks
 
 import groovy.text.SimpleTemplateEngine
 import net.researchgate.release.BaseScmAdapter
+import net.researchgate.release.PluginHelper
 import net.researchgate.release.ReleaseExtension
 import net.researchgate.release.ReleasePlugin
 import org.apache.tools.ant.BuildException
@@ -35,7 +36,7 @@ class BaseReleaseTask extends DefaultTask {
     @Internal
     BaseScmAdapter getScmAdapter() {
         if (extension.scmAdapter == null) {
-            project.getPlugins().getPlugin(ReleasePlugin.class).createScmAdapter()
+            project.getPlugins().getPlugin(ReleasePlugin.class).createScmAdapter(new PluginHelper(project, extension))
         }
         return extension.scmAdapter
     }

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginCreateReleaseTagTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginCreateReleaseTagTests.groovy
@@ -62,7 +62,7 @@ class GitReleasePluginCreateReleaseTagTests extends GitSpecification {
         project = new ProjectBuilder().withProjectDir(localDir).build()
         project.plugins.apply(BasePlugin.class)
         project.plugins.apply(ReleasePlugin.class)
-        helper = new PluginHelper(project: project, extension: project.extensions['release'] as ReleaseExtension)
+        helper = new PluginHelper(project, project.extensions['release'] as ReleaseExtension)
     }
 
     def 'createReleaseTag should create tag and push to remote'() {

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
@@ -48,13 +48,13 @@ class GitReleasePluginTests extends Specification {
         project = ProjectBuilder.builder().withName("GitReleasePluginTest").withProjectDir(localRepo).build()
         project.version = "1.1"
         project.plugins.apply(BasePlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
+        project.plugins.apply(ReleasePlugin.class)
 
         project.file("somename.txt").withWriter {it << "test"}
         this.executor.exec(['git', 'add', 'somename.txt'], failOnStderr: true, directory: localRepo, env: [:])
         this.executor.exec(['git', 'commit', "-m", "test", 'somename.txt'], failOnStderr: true, directory: localRepo, env: [:])
 
-        releasePlugin.createScmAdapter()
+        ReleasePlugin.createScmAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension))
 
         def props = project.file("gradle.properties")
         props.withWriter { it << "version=${project.version}" }

--- a/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
+++ b/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
@@ -27,12 +27,12 @@ public class PluginHelperTagNameTests extends Specification {
         project = ProjectBuilder.builder().withName("ReleasePluginTest").withProjectDir(testDir).build()
         project.version = '1.1'
         project.plugins.apply(BasePlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
+        project.plugins.apply(ReleasePlugin.class)
         project.extensions.release.scmAdapters = [TestAdapter]
 
-        releasePlugin.createScmAdapter()
+        ReleasePlugin.createScmAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension))
 
-        helper = new PluginHelper(project: project, extension: project.extensions['release'] as ReleaseExtension)
+        helper = new PluginHelper(project, project.extensions['release'] as ReleaseExtension)
     }
 
     def 'by default the tag name is version'() {

--- a/src/test/groovy/net/researchgate/release/PluginHelperVersionPropertyFileTests.groovy
+++ b/src/test/groovy/net/researchgate/release/PluginHelperVersionPropertyFileTests.groovy
@@ -28,11 +28,11 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
         project = ProjectBuilder.builder().withName("ReleasePluginTest").withProjectDir(testDir).build()
         project.version = '1.1'
         project.plugins.apply(BasePlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
+        project.plugins.apply(ReleasePlugin.class)
         project.extensions.release.scmAdapters = [TestAdapter]
-        releasePlugin.createScmAdapter()
+        ReleasePlugin.createScmAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension))
 
-        helper = new PluginHelper(project: project, extension: project.extensions['release'] as ReleaseExtension)
+        helper = new PluginHelper(project, project.extensions['release'] as ReleaseExtension)
 
         def props = project.file("gradle.properties")
         props.withWriter {it << "version=${project.version}"}
@@ -44,7 +44,7 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
 
     def 'should find gradle.properties by default'() {
         expect:
-        helper.findPropertiesFile().name == 'gradle.properties'
+        helper.propertiesFile.name == 'gradle.properties'
     }
 
     def 'should find properties from convention'() {
@@ -55,7 +55,7 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
             versionPropertyFile.set('custom.properties')
         }
         expect:
-        helper.findPropertiesFile().name == 'custom.properties'
+        helper.propertiesFile.name == 'custom.properties'
     }
 
     def 'by default should update `version` property from props file'() {

--- a/src/test/groovy/net/researchgate/release/ReleasePluginCheckSnapshotDependenciesTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginCheckSnapshotDependenciesTests.groovy
@@ -26,10 +26,10 @@ public class ReleasePluginCheckSnapshotDependenciesTests extends Specification {
         project = ProjectBuilder.builder().withName("ReleasePluginTest").build()
         project.plugins.apply(BasePlugin.class)
         project.plugins.apply(GroovyPlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
+        project.plugins.apply(ReleasePlugin.class)
         project.extensions.release.scmAdapters = [TestAdapter]
 
-        releasePlugin.createScmAdapter()
+        ReleasePlugin.createScmAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension))
     }
 
     def 'when no deps then no exception'() {

--- a/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
@@ -36,10 +36,10 @@ class ReleasePluginTests extends Specification {
             w.write 'version=1.2\n'
         }
         project.plugins.apply(BasePlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
+        project.plugins.apply(ReleasePlugin.class)
         project.extensions.release.scmAdapters = [TestAdapter]
 
-        releasePlugin.createScmAdapter()
+        ReleasePlugin.createScmAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension))
     }
 
     def 'plugin is successfully applied'() {

--- a/src/test/groovy/net/researchgate/release/SvnAdapterTests.groovy
+++ b/src/test/groovy/net/researchgate/release/SvnAdapterTests.groovy
@@ -23,7 +23,7 @@ class SvnAdapterTests extends Specification {
         project.apply plugin: ReleasePlugin
         project.version = '1.0.0'
 
-        svnAdapter = new SvnAdapter(project, [:])
+        svnAdapter = new SvnAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension, [:]))
         svnAdapter.executor = Mock(Executor)
         svnAdapter.attributes.svnUrl  = 'svn://server/repo'
         svnAdapter.attributes.svnRev  = 123

--- a/src/test/groovy/net/researchgate/release/TestAdapter.groovy
+++ b/src/test/groovy/net/researchgate/release/TestAdapter.groovy
@@ -10,12 +10,10 @@
 
 package net.researchgate.release
 
-import org.gradle.api.Project
-
 class TestAdapter extends BaseScmAdapter {
 
-    TestAdapter(Project project, Map<String, Object> attributes) {
-        super(project, attributes)
+    TestAdapter(PluginHelper pluginHelper) {
+        super(pluginHelper, new Cacheable(pluginHelper.toCacheable()))
     }
 
     class TestConfig {
@@ -53,5 +51,16 @@ class TestAdapter extends BaseScmAdapter {
 
     @Override
     void revert() {
+    }
+
+    static class Cacheable extends BaseScmAdapter.Cacheable {
+
+        Cacheable(CacheablePluginHelper cacheablePluginHelper) {
+            super(cacheablePluginHelper)
+        }
+
+        @Override
+        void revert() {
+        }
     }
 }


### PR DESCRIPTION
Gradle 9 doesn't allow using arbitrary providers as build events listeners when the Configuration Cache is used