### PR TITLE
[chore] Added option to wrap version with single quote or not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin
 out
 
 /.nb-gradle/
+**/lib

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Below are some properties of the Release Plugin Convention that can be used to c
 		<td>-SNAPSHOT</td>
 		<td>The version suffix used by the project's version (If used)</td>
 	</tr>
+	<tr>
+		<td>wrapVersionWithSingleQuote</td>
+		<td>true</td>
+		<td>The version is enclosed with single quotes in the commit message [Gradle Release Plugin] - new version commit: '1.6.7-SNAPSHOT' instead of [Gradle Release Plugin] - new version commit: 1.6.7-SNAPSHOT.</td>
+	</tr>
+
 </table>
 
 Below are some properties of the Release Plugin Convention that are specific to version control.<br>

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
     testCompile("org.spockframework:spock-core:2.1-groovy-2.5") { exclude group: 'org.codehaus.groovy' }
-    testCompile "org.eclipse.jgit:org.eclipse.jgit:6.8.0.202311291450-r"
+    testCompile "org.eclipse.jgit:org.eclipse.jgit:5.0.3.201809091024-r"
     testCompile "cglib:cglib-nodep:3.2.8"
     testImplementation gradleTestKit()
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
     testCompile("org.spockframework:spock-core:2.1-groovy-2.5") { exclude group: 'org.codehaus.groovy' }
-    testCompile "org.eclipse.jgit:org.eclipse.jgit:5.0.3.201809091024-r"
+    testCompile "org.eclipse.jgit:org.eclipse.jgit:6.8.0.202311291450-r"
     testCompile "cglib:cglib-nodep:3.2.8"
     testImplementation gradleTestKit()
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
@@ -64,7 +64,7 @@ class ReleaseExtension {
     final Property<String> snapshotSuffix = project.objects.property(String.class).convention('-SNAPSHOT')
 
     @Input
-    final Property<Boolean> wrapVersionWithSingleQuote = project.objects.property(Boolean.class).convention(true)
+    final Property<Boolean> wrapVersionWithSingleQuote = project.objects.property(Boolean.class).convention(false)
 
     @Input
     final Property<String> tagTemplate = project.objects.property(String.class).convention('$version')

--- a/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
@@ -64,7 +64,7 @@ class ReleaseExtension {
     final Property<String> snapshotSuffix = project.objects.property(String.class).convention('-SNAPSHOT')
 
     @Input
-    final Property<Boolean> wrapVersionWithSingleQuote = project.objects.property(Boolean.class).convention(false)
+    final Property<Boolean> wrapVersionWithSingleQuote = project.objects.property(Boolean.class).convention(true)
 
     @Input
     final Property<String> tagTemplate = project.objects.property(String.class).convention('$version')

--- a/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
@@ -64,6 +64,9 @@ class ReleaseExtension {
     final Property<String> snapshotSuffix = project.objects.property(String.class).convention('-SNAPSHOT')
 
     @Input
+    final Property<Boolean> wrapVersionWithSingleQuote = project.objects.property(Boolean.class).convention(true)
+
+    @Input
     final Property<String> tagTemplate = project.objects.property(String.class).convention('$version')
 
     @Input

--- a/src/main/groovy/net/researchgate/release/tasks/BaseReleaseTask.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/BaseReleaseTask.groovy
@@ -115,7 +115,8 @@ class BaseReleaseTask extends DefaultTask {
                 "name"   : project.name
         ]
         tagName = engine.createTemplate(extension.tagTemplate.get()).make(binding).toString()
-        return tagName
+        String finalTagName = extension.wrapVersionWithSingleQuote.get() ? "'${tagName}'" : "${tagName}"
+        return finalTagName
     }
 
     String findProperty(String key, Object defaultVal = null, String deprecatedKey = null) {

--- a/src/main/groovy/net/researchgate/release/tasks/CommitNewVersion.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/CommitNewVersion.groovy
@@ -1,6 +1,5 @@
 package net.researchgate.release.tasks
 
-import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 
 class CommitNewVersion extends BaseReleaseTask {
@@ -12,7 +11,7 @@ class CommitNewVersion extends BaseReleaseTask {
 
     @TaskAction
     def commitNewVersion() {
-        String message = extension.newVersionCommitMessage.get() + " '${tagName()}'."
+        String message = extension.newVersionCommitMessage.get() + " ${tagName()}."
         if (extension.preCommitText.get()) {
             message = "${extension.preCommitText.get()} ${message}"
         }

--- a/src/main/groovy/net/researchgate/release/tasks/CreateReleaseTag.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/CreateReleaseTag.groovy
@@ -12,7 +12,7 @@ class CreateReleaseTag extends BaseReleaseTask {
 
     @TaskAction
     void createReleaseTag() {
-        def message = extension.tagCommitMessage.get() + " '${tagName()}'."
+        def message = extension.tagCommitMessage.get() + " ${tagName()}."
         if (extension.preCommitText.get()) {
             message = "${extension.preCommitText.get()} ${message}"
         }

--- a/src/main/groovy/net/researchgate/release/tasks/PreTagCommit.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/PreTagCommit.groovy
@@ -21,7 +21,7 @@ class PreTagCommit extends BaseReleaseTask {
         Map<String, Object> projectAttributes = extension.attributes
         if (projectAttributes.usesSnapshot || projectAttributes.versionModified || projectAttributes.propertiesFileCreated) {
             // should only be committed if the project was using a snapshot version.
-            String message = extension.preTagCommitMessage.get() + " '${tagName()}'."
+            String message = extension.preTagCommitMessage.get() + " ${tagName()}."
             if (extension.preCommitText.get()) {
                 message = "${extension.preCommitText.get()} ${message}"
             }

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
@@ -67,17 +67,23 @@ class GitReleasePluginTests extends Specification {
 
     def 'when requireBranch is configured then throw exception when different branch'() {
         given:
+        // Ensure we're on a known branch (master) for this test
+        this.executor.exec(['git', 'checkout', '-B', 'master'], failOnStderr: false, directory: localRepo, env: [:])
+        
+        // Get the actual current branch name
+        def currentBranch = this.executor.exec(['git', 'branch', '--show-current'], failOnStderr: false, directory: localRepo, env: [:]).trim()
+        
         project.release.git.requireBranch.set('myBranch')
         when:
         (new GitAdapter(project, [:])).init()
         then:
         GradleException ex = thrown()
-        ex.message == 'Current Git branch is "master" and not "myBranch".'
+        ex.message == "Current Git branch is \"${currentBranch}\" and not \"myBranch\"."
     }
 
     def 'when requireBranch is configured using a regex that matches current branch then don\'t throw exception'() {
         given:
-        project.release.git.requireBranch.set(/myBranch|master/)
+        project.release.git.requireBranch.set(/myBranch|master|main/)
         when:
         (new GitAdapter(project, [:])).init()
         then:


### PR DESCRIPTION
Added a new boolean property to specify if version should be wrapped with single-quote

The default behavior right now is like this 

`Update for next development version '1.6.19-SNAPSHOT'.` 

Addint this feature and setting the new prooperty `wrapVersionWithSingleQuote=false`, it should result into this 
`Update for next development version 1.6.19-SNAPSHOT.` 

without the single quote