### PR TITLE
Allow to configure the version file encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ release {
     newVersionCommitMessage = '[Gradle Release Plugin] - new version commit: '
     tagTemplate = '${version}'
     versionPropertyFile = 'gradle.properties'
+    versionPropertyFileEncoding = 'ISO-8859-1'
     versionProperties = []
     snapshotSuffix = '-SNAPSHOT'
     buildTasks = []

--- a/src/main/groovy/net/researchgate/release/PluginHelper.groovy
+++ b/src/main/groovy/net/researchgate/release/PluginHelper.groovy
@@ -86,7 +86,7 @@ class PluginHelper {
             }
 
             if (useAutomaticVersion() || promptYesOrNo("[$propertiesFile.canonicalPath] not found, create it with version = ${project.version}")) {
-                writeVersion(propertiesFile, 'version', project.version)
+                writeVersion(propertiesFile, extension.versionPropertyFileEncoding.get(), 'version', project.version)
                 attributes.propertiesFileCreated = true
             } else {
                 log.debug "[$propertiesFile.canonicalPath] was not found, and user opted out of it being created. Throwing exception."
@@ -100,13 +100,13 @@ class PluginHelper {
         cacheablePluginHelper.propertiesFile
     }
 
-    protected void writeVersion(File file, String key, version) {
+    protected void writeVersion(File file, String versionPropertyFileEncoding, String key, version) {
         try {
             if (!file.file) {
-                project.ant.echo(file: file, message: "$key=$version")
+                project.ant.echo(file: file, encoding: versionPropertyFileEncoding, message: "$key=$version")
             } else {
                 // we use replace here as other ant tasks escape and modify the whole file
-                project.ant.replaceregexp(file: file, byline: true) {
+                project.ant.replaceregexp(file: file, byline: true, encoding: versionPropertyFileEncoding) {
                     regexp(pattern: "^(\\s*)$key((\\s*[=|:]\\s*)|(\\s+)).+\$")
                     substitution(expression: "\\1$key\\2$version")
                 }
@@ -174,7 +174,7 @@ class PluginHelper {
             project.subprojects?.each { it.version = newVersion }
             List<String> versionProperties = extension.versionProperties.get() + 'version'
             findOrCreatePropertiesFile()
-            versionProperties.each { writeVersion(propertiesFile, it, project.version) }
+            versionProperties.each { writeVersion(propertiesFile, extension.versionPropertyFileEncoding.get(), it, project.version) }
         }
     }
 

--- a/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleaseExtension.groovy
@@ -70,6 +70,9 @@ class ReleaseExtension {
     final Property<String> versionPropertyFile = project.objects.property(String.class).convention('gradle.properties')
 
     @Input
+    final Property<String> versionPropertyFileEncoding = project.objects.property(String.class).convention('ISO-8859-1')
+
+    @Input
     final ListProperty<String> versionProperties = project.objects.listProperty(String.class).convention([])
 
     @Input

--- a/src/main/groovy/net/researchgate/release/tasks/BaseReleaseTask.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/BaseReleaseTask.groovy
@@ -69,7 +69,7 @@ class BaseReleaseTask extends DefaultTask {
             }
 
             if (useAutomaticVersion() || promptYesOrNo("[$propertiesFile.canonicalPath] not found, create it with version = ${project.version}")) {
-                writeVersion(propertiesFile, 'version', project.version)
+                writeVersion(propertiesFile, extension.versionPropertyFileEncoding.get(), 'version', project.version)
                 projectAttributes.propertiesFileCreated = true
             } else {
                 log.debug "[$propertiesFile.canonicalPath] was not found, and user opted out of it being created. Throwing exception."
@@ -79,13 +79,13 @@ class BaseReleaseTask extends DefaultTask {
         propertiesFile
     }
 
-    protected void writeVersion(File file, String key, version) {
+    protected void writeVersion(File file, String versionPropertyFileEncoding, String key, version) {
         try {
             if (!file.file) {
-                getProject().ant.echo(file: file, message: "$key=$version")
+                getProject().ant.echo(file: file, encoding: versionPropertyFileEncoding, message: "$key=$version")
             } else {
                 // we use replace here as other ant tasks escape and modify the whole file
-                getProject().ant.replaceregexp(file: file, byline: true) {
+                getProject().ant.replaceregexp(file: file, byline: true, encoding: versionPropertyFileEncoding) {
                     regexp(pattern: "^(\\s*)$key((\\s*[=|:]\\s*)|(\\s+)).+\$")
                     substitution(expression: "\\1$key\\2$version")
                 }

--- a/src/main/groovy/net/researchgate/release/tasks/PrepareVersions.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/PrepareVersions.groovy
@@ -36,7 +36,7 @@ class PrepareVersions extends BaseReleaseTask {
         }
 
         if (useAutomaticVersion() || promptYesOrNo("[$propertiesFile.canonicalPath] not found, create it with version = ${project.version}")) {
-            writeVersion(propertiesFile, 'version', project.version)
+            writeVersion(propertiesFile, extension.versionPropertyFileEncoding.get(), 'version', project.version)
             extension.attributes.propertiesFileCreated = true
         } else {
             log.debug "[$propertiesFile.canonicalPath] was not found, and user opted out of it being created. Throwing exception."

--- a/src/main/groovy/net/researchgate/release/tasks/UnSnapshotVersion.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/UnSnapshotVersion.groovy
@@ -33,7 +33,7 @@ class UnSnapshotVersion extends BaseReleaseTask {
         }
 
         Properties properties = new Properties()
-        propertiesFile.withReader { properties.load(it) }
+        propertiesFile.withReader(extension.versionPropertyFileEncoding.get()) { properties.load(it) }
 
         assert properties.version, "[$propertiesFile.canonicalPath] contains no 'version' property"
         assert extension.versionPatterns.keySet().any { (properties.version =~ it).find() },


### PR DESCRIPTION
Without this setting, the JVM default encoding is used. This can easily break files if they contain non-ASCII characters. A properties file for example by definintion is ISO-8859-1 encoded. Java 18+ use UTF-8 as default encoding if nothing else is configured. If you now manipulate the version file using UTF-8, it gets crippled if it contains non-ASCII characters.
With this new setting the encoding can be configured, with the appropriate default setting according to the default for the file.